### PR TITLE
Fixing libs relocation in shadow builds and other

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,10 +1,11 @@
+//file:noinspection GroovyAssignabilityCheck
 plugins {
     id 'java-library'
     id 'maven-publish'
 }
 
 dependencies {
-    implementation project(':common')
+    compileOnly project(path: ':common', configuration: 'shadow')
 
     compileOnly 'org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT'
     compileOnly 'org.jetbrains:annotations:22.0.0'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,3 +1,8 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+}
+
 dependencies {
     implementation project(':common')
 
@@ -5,28 +10,26 @@ dependencies {
     compileOnly 'org.jetbrains:annotations:22.0.0'
 }
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            shadow.component(it)
-            afterEvaluate {
-                artifact javadocsJar
-            }
-        }
-    }
-    repositories {
-        mavenLocal()
-    }
-}
-
-shadowJar {
-    classifier = null
-    relocate ':common', 'me.william278.husksync'
-}
-
 repositories {
     mavenCentral()
     maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
+}
+
+afterEvaluate {
+    publishing {
+        publications {
+            maven(MavenPublication) {
+                groupId = "${rootProject.group}.${rootProject.name.toLowerCase()}"
+                artifactId = project.name
+
+                from components.java
+                artifact javadocsJar
+            }
+        }
+        repositories {
+            mavenLocal()
+        }
+    }
 }
 
 task javadocs(type: Javadoc) {
@@ -39,6 +42,6 @@ task javadocs(type: Javadoc) {
 }
 
 task javadocsJar(type: Jar, dependsOn: javadocs) {
-    classifier = 'javadoc'
+    archiveClassifier.set 'javadoc'
     from javadocs.destinationDir
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,33 +1,24 @@
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-}
-
 plugins {
-    id 'com.github.johnrengelman.shadow' version '7.1.0' apply false
+    id 'org.ajoberstar.grgit' version '4.1.1'
     id 'java'
 }
 
-allprojects {
-    group 'me.William278'
-    version '1.3.2'
+group 'me.william278'
+version "$ext.plugin_version+${versionMetadata()}"
 
-    compileJava { options.encoding = 'UTF-8' }
-    tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
-    javadoc { options.encoding = 'UTF-8' }
+ext {
+    set 'version', version.toString()
 }
 
-logger.lifecycle('Building HuskSync v' + version.toString())
-
-subprojects {
-    apply plugin: 'com.github.johnrengelman.shadow'
+import org.apache.tools.ant.filters.ReplaceTokens
+allprojects {
     apply plugin: 'java'
     apply plugin: 'maven-publish'
 
-    compileJava {
-        options.release = 16
-    }
+    compileJava.options.encoding = 'UTF-8'
+    javadoc.options.encoding = 'UTF-8'
+
+    compileJava.options.release.set 16
 
     repositories {
         mavenLocal()
@@ -39,4 +30,28 @@ subprojects {
         maven { url 'https://repo.alessiodp.com/releases/' }
         maven { url 'https://jitpack.io' }
     }
+
+    dependencies {
+        implementation 'redis.clients:jedis:3.7.1'
+    }
+
+    processResources {
+        filter ReplaceTokens as Class, beginToken: '${', endToken: '}',
+                tokens: rootProject.ext.properties
+    }
+}
+
+subprojects {
+    version rootProject.version
+    archivesBaseName = "${rootProject.name}-${project.name.capitalize()}"
+}
+
+logger.lifecycle("Building HuskSync ${version} by Willam278")
+
+def versionMetadata() {
+    if (grgit == null) {
+        return System.getenv("GITHUB_RUN_NUMBER") ? 'build.' + System.getenv("GITHUB_RUN_NUMBER") : 'unknown'
+    }
+
+    return 'rev.'+ grgit.head().abbreviatedId + (grgit.status().clean ? '' : '-indev')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 plugins {
+    id 'com.github.johnrengelman.shadow' version '7.1.0'
     id 'org.ajoberstar.grgit' version '4.1.1'
     id 'java'
 }
@@ -11,9 +12,10 @@ ext {
 }
 
 import org.apache.tools.ant.filters.ReplaceTokens
+
 allprojects {
+    apply plugin: 'com.github.johnrengelman.shadow'
     apply plugin: 'java'
-    apply plugin: 'maven-publish'
 
     compileJava.options.encoding = 'UTF-8'
     javadoc.options.encoding = 'UTF-8'
@@ -32,7 +34,10 @@ allprojects {
     }
 
     dependencies {
-        implementation 'redis.clients:jedis:3.7.1'
+        implementation('redis.clients:jedis:3.7.1') {
+            //noinspection GroovyAssignabilityCheck
+            exclude module: 'slf4j-api'
+        }
     }
 
     processResources {
@@ -44,14 +49,23 @@ allprojects {
 subprojects {
     version rootProject.version
     archivesBaseName = "${rootProject.name}-${project.name.capitalize()}"
+
+    if (['bukkit', 'bungeecord', 'velocity', 'plugin'].contains(project.name)) {
+        shadowJar {
+            destinationDirectory.set(file("$rootDir/target"))
+            archiveClassifier.set('')
+        }
+        jar.dependsOn shadowJar
+        clean.delete "$rootDir/target"
+    }
 }
 
 logger.lifecycle("Building HuskSync ${version} by Willam278")
 
+@SuppressWarnings('GrMethodMayBeStatic')
 def versionMetadata() {
     if (grgit == null) {
         return System.getenv("GITHUB_RUN_NUMBER") ? 'build.' + System.getenv("GITHUB_RUN_NUMBER") : 'unknown'
     }
-
-    return 'rev.'+ grgit.head().abbreviatedId + (grgit.status().clean ? '' : '-indev')
+    return 'rev.' + grgit.head().abbreviatedId + (grgit.status().clean ? '' : '-indev')
 }

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -1,9 +1,7 @@
 dependencies {
-    compileOnly project(':common')
-    compileOnly project(':api')
+    implementation project(':api')
     implementation project(path: ':common', configuration: 'shadow')
 
-    compileOnly 'redis.clients:jedis:3.7.1'
     implementation 'org.bstats:bstats-bukkit:2.2.1'
     implementation 'de.themoep:minedown:1.7.1-SNAPSHOT'
 
@@ -13,8 +11,9 @@ dependencies {
 }
 
 shadowJar {
-    relocate 'org.bstats', 'me.William278.husksync.libraries.bstats.bukkit'
-    relocate 'de.themoep', 'me.William278.husksync.libraries.minedown.standard'
-}
+    relocate 'de.themoep', 'me.william278.husksync.libraries'
+    relocate 'org.bstats', 'me.william278.husksync.libraries.bstats'
 
-tasks.register('prepareKotlinBuildScriptModel'){}
+    relocate 'redis.clients', 'me.william278.husksync.libraries'
+    relocate 'org.apache', 'me.william278.husksync.libraries'
+}

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: HuskSync
-version: '@version@'
+version: ${version}
 main: me.william278.husksync.HuskSyncBukkit
 api-version: 1.16
 author: William278

--- a/bungeecord/build.gradle
+++ b/bungeecord/build.gradle
@@ -1,8 +1,7 @@
 dependencies {
-    compileOnly project(':common')
     implementation project(path: ':common', configuration: 'shadow')
 
-    compileOnly 'redis.clients:jedis:4.0.1'
+    implementation 'com.zaxxer:HikariCP:5.0.1'
     implementation 'org.bstats:bstats-bungeecord:2.2.1'
     implementation 'de.themoep:minedown:1.7.1-SNAPSHOT'
     implementation 'net.byteflux:libby-bungee:1.1.5'
@@ -11,10 +10,17 @@ dependencies {
 }
 
 shadowJar {
-    relocate 'com.zaxxer', 'me.William278.husksync.libraries.hikari'
-    relocate 'org.bstats', 'me.William278.husksync.libraries.bstats.bungee'
-    relocate 'de.themoep', 'me.William278.husksync.libraries.minedown.standard'
-    relocate 'net.byteflux', 'me.William278.husksync.libraries.libby.bungee'
-}
+    relocate 'de.themoep', 'me.william278.husksync.libraries'
+    relocate 'net.byteflux', 'me.william278.husksync.libraries'
+    relocate 'org.bstats', 'me.william278.husksync.libraries.bstats'
 
-tasks.register('prepareKotlinBuildScriptModel'){}
+    relocate 'redis.clients', 'me.william278.husksync.libraries'
+    relocate 'org.apache', 'me.william278.husksync.libraries'
+
+    relocate 'com.zaxxer', 'me.william278.husksync.libraries'
+
+    dependencies {
+        //noinspection GroovyAssignabilityCheck
+        exclude dependency(':slf4j-api')
+    }
+}

--- a/bungeecord/src/main/resources/bungee.yml
+++ b/bungeecord/src/main/resources/bungee.yml
@@ -1,5 +1,5 @@
 name: HuskSync
-version: '@version@'
+version: ${version}
 main: me.william278.husksync.HuskSyncBungeeCord
 author: William278
 description: 'A modern, cross-server player data synchronization system'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,28 +1,7 @@
 dependencies {
-    implementation 'redis.clients:jedis:4.0.1'
-    implementation 'com.zaxxer:HikariCP:5.0.1'
-}
-
-import org.apache.tools.ant.filters.ReplaceTokens
-task updateVersion(type: Copy) {
-    from('src/main/resources') {
-        include 'plugin.yml'
-        include 'bungee.yml'
-    }
-    into 'build/sources/resources/'
-    filter(ReplaceTokens, tokens: [version: '' + project.version])
-}
-
-processResources {
-    duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    dependsOn updateVersion
-    from 'build/sources/resources'
+    compileOnly 'com.zaxxer:HikariCP:5.0.1'
 }
 
 shadowJar {
-    dependsOn processResources
-
-    // Exclude some unnecessary files
-    exclude "**/module-info.class"
-    exclude "module-info.class"
+    relocate 'com.zaxxer', 'me.william278.husksync.libraries'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,4 @@
 javaVersion=16
+
+plugin_version=1.3.2
+plugin_archive=husksync

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,30 +1,27 @@
+//file:noinspection GroovyAssignabilityCheck
+plugins {
+    id 'maven-publish'
+}
+
 dependencies {
-    implementation project(path: ":common", configuration: 'shadow')
-    implementation project(path: ":api", configuration: 'shadow')
-    implementation project(path: ":bukkit", configuration: 'shadow')
-    implementation project(path: ":bungeecord", configuration: 'shadow')
-    implementation project(path: ":velocity", configuration: 'shadow')
+    implementation project(path: ':bukkit', configuration: 'shadow')
+    implementation project(path: ':bungeecord', configuration: 'shadow')
+    implementation project(path: ':velocity', configuration: 'shadow')
 }
 
 shadowJar {
-    // Relocations
-    relocate 'redis.clients', 'me.William278.husksync.libraries.jedis'
-
-    destinationDirectory.set(file("$rootDir/target/"))
-    archiveBaseName.set('HuskSync')
-    archiveClassifier.set('')
-
-    build {
-        dependsOn tasks.named("shadowJar")
+    dependencies {
+        exclude dependency(':jedis')
+        exclude dependency(':commons-pool2')
     }
 }
 
 publishing {
     publications {
         mavenJava(MavenPublication) {
-            groupId = 'me.William278'
-            artifactId = 'HuskSync-plugin'
-            version = "$project.version"
+            groupId = 'me.william278'
+            artifactId = 'husksync-plugin'
+            version = "$rootProject.version"
 
             artifact shadowJar
         }

--- a/velocity/build.gradle
+++ b/velocity/build.gradle
@@ -1,21 +1,26 @@
 dependencies {
-    compileOnly project(':common')
     implementation project(path: ':common', configuration: 'shadow')
 
-    compileOnly 'redis.clients:jedis:4.0.1'
+    implementation 'com.zaxxer:HikariCP:5.0.1'
     implementation 'org.bstats:bstats-velocity:2.2.1'
     implementation 'de.themoep:minedown-adventure:1.7.1-SNAPSHOT'
     implementation 'net.byteflux:libby-velocity:1.1.5'
 
     compileOnly 'com.velocitypowered:velocity-api:3.1.0'
-    annotationProcessor 'com.velocitypowered:velocity-api:3.1.0'
 }
 
 shadowJar {
-    relocate 'com.zaxxer', 'me.William278.husksync.libraries.hikari'
-    relocate 'org.bstats', 'me.William278.husksync.libraries.bstats.velocity'
-    relocate 'de.themoep', 'me.William278.husksync.libraries.minedown.adventure'
-    relocate 'net.byteflux', 'me.William278.husksync.libraries.libby.velocity'
-}
+    relocate 'de.themoep', 'me.william278.husksync.libraries'
+    relocate 'net.byteflux', 'me.william278.husksync.libraries'
+    relocate 'org.bstats', 'me.william278.husksync.libraries.bstats'
 
-tasks.register('prepareKotlinBuildScriptModel'){}
+    relocate 'redis.clients', 'me.william278.husksync.libraries'
+    relocate 'org.apache', 'me.william278.husksync.libraries'
+
+    relocate 'com.zaxxer', 'me.william278.husksync.libraries'
+
+    dependencies {
+        //noinspection GroovyAssignabilityCheck
+        exclude dependency(':slf4j-api')
+    }
+}

--- a/velocity/src/main/java/me/william278/husksync/HuskSyncVelocity.java
+++ b/velocity/src/main/java/me/william278/husksync/HuskSyncVelocity.java
@@ -7,6 +7,7 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import me.william278.husksync.migrator.MPDBMigrator;
@@ -31,20 +32,11 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.logging.Level;
 
-import static me.william278.husksync.HuskSyncVelocity.VERSION;
-
-@Plugin(
-        id = "husksync",
-        name = "HuskSync",
-        version = VERSION,
-        description = "A modern, cross-server player data synchronization system",
-        authors = {"William278"},
-        url = "https://william278.net"
-)
+@Plugin(id = "husksync")
 public class HuskSyncVelocity {
 
     // Plugin version
-    public static final String VERSION = "1.3.2";
+    public static String VERSION = null;
 
     // Velocity bStats ID (different from Bukkit and BungeeCord)
     private static final int METRICS_ID = 13489;
@@ -95,11 +87,13 @@ public class HuskSyncVelocity {
     }
 
     @Inject
-    public HuskSyncVelocity(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory, Metrics.Factory metricsFactory) {
+    public HuskSyncVelocity(ProxyServer server, Logger logger, @DataDirectory Path dataDirectory, Metrics.Factory metricsFactory, PluginContainer pluginContainer) {
         this.server = server;
         this.logger = logger;
         this.dataDirectory = dataDirectory;
         this.metricsFactory = metricsFactory;
+
+        pluginContainer.getDescription().getVersion().ifPresent(s -> VERSION = s);
     }
 
     @Subscribe

--- a/velocity/src/main/resources/velocity-plugin.json
+++ b/velocity/src/main/resources/velocity-plugin.json
@@ -1,0 +1,12 @@
+{
+  "id": "husksync",
+  "name": "HuskSync",
+  "version": "${version}",
+  "description": "A modern, cross-server player data synchronization system",
+  "url": "https://william278.net",
+  "authors": [
+    "William278"
+  ],
+  "dependencies": [],
+  "main": "me.william278.husksync.HuskSyncVelocity"
+}


### PR DESCRIPTION
Changed relocation of libraries in the shaded builds of the plugin, which significantly increased the size of the output archive.
Changed version format to more accurately determine the version of the plugin.
Added shading for main modules (bukkit, bungeecord, velocity) for direct use.
Slightly changed format of Gradle project in general.

Think about transferring `Jedis` to real-time downloadable libraries when the server is turned on.