### PR TITLE
Fixed the connection leaks in isInactive()

### DIFF
--- a/common/src/main/java/net/william278/husksync/proxy/data/sql/Database.java
+++ b/common/src/main/java/net/william278/husksync/proxy/data/sql/Database.java
@@ -21,8 +21,8 @@ public abstract class Database {
     public abstract Connection getConnection() throws SQLException;
 
     public boolean isInactive() {
-        try {
-            return getConnection() == null;
+        try (Connection connection = getConnection()) {
+            return connection == null || !connection.isValid(0);
         } catch (SQLException e) {
             return true;
         }


### PR DESCRIPTION
The getConnection()  == null causes connection leaks; Meanwhile, when the connection corrupted, it may not give correct result.