### PR TITLE
hotfix(Bukkit): fix death sync event when setting health of 0

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -15,6 +15,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
@@ -51,6 +52,13 @@ public class BukkitEventListener extends EventListener implements Listener {
     public void onWorldSave(@NotNull WorldSaveEvent event) {
         CompletableFuture.runAsync(() -> super.handleAsyncWorldSave(event.getWorld().getPlayers().stream()
                 .map(BukkitPlayer::adapt).collect(Collectors.toList())));
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onPlayerDeath(PlayerDeathEvent event) {
+      if (cancelPlayerEvent(BukkitPlayer.adapt(event.getEntity()))) {
+        event.getDrops().clear();
+      }
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/bukkit/src/main/java/net/william278/husksync/player/BukkitPlayer.java
+++ b/bukkit/src/main/java/net/william278/husksync/player/BukkitPlayer.java
@@ -82,7 +82,7 @@ public class BukkitPlayer extends OnlineUser {
             if (statusDataFlags.contains(StatusDataFlag.SET_HEALTH)) {
                 final double currentHealth = player.getHealth();
                 if (statusData.health != currentHealth) {
-                    double healthToSet = currentHealth > currentMaxHealth ? currentMaxHealth : statusData.health;
+                    final double healthToSet = currentHealth > currentMaxHealth ? currentMaxHealth : statusData.health;
                     if (healthToSet <= 0) {
                         Bukkit.getScheduler().runTask(BukkitHuskSync.getInstance(), () -> player.setHealth(healthToSet));
                     } else {

--- a/bukkit/src/main/java/net/william278/husksync/player/BukkitPlayer.java
+++ b/bukkit/src/main/java/net/william278/husksync/player/BukkitPlayer.java
@@ -82,7 +82,12 @@ public class BukkitPlayer extends OnlineUser {
             if (statusDataFlags.contains(StatusDataFlag.SET_HEALTH)) {
                 final double currentHealth = player.getHealth();
                 if (statusData.health != currentHealth) {
-                    player.setHealth(currentHealth > currentMaxHealth ? currentMaxHealth : statusData.health);
+                    double healthToSet = currentHealth > currentMaxHealth ? currentMaxHealth : statusData.health;
+                    if (healthToSet <= 0) {
+                        Bukkit.getScheduler().runTask(BukkitHuskSync.getInstance(), () -> player.setHealth(healthToSet));
+                    } else {
+                        player.setHealth(healthToSet);
+                    }
                 }
 
                 if (statusData.healthScale != 0d) {


### PR DESCRIPTION
This fix sync failed when we set to player the health of 0 hp, which call the PlayerDeathEvent in async, while the event need to be called sync