### PR TITLE
Make event priorities configurable for `DEATH`, `JOIN` and `QUIT` events for better plugin compatibility

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitDeathEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitDeathEventListener.java
@@ -1,0 +1,37 @@
+package net.william278.husksync.listener;
+
+import net.william278.husksync.config.Settings;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.jetbrains.annotations.NotNull;
+
+public interface BukkitDeathEventListener extends Listener {
+
+    boolean handleEvent(@NotNull Settings.EventType type, @NotNull Settings.EventPriority priority);
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    default void onPlayerDeathHighest(@NotNull PlayerDeathEvent event) {
+        if (handleEvent(Settings.EventType.DEATH_LISTENER, Settings.EventPriority.HIGHEST)) {
+            handlePlayerDeath(event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    default void onPlayerDeath(@NotNull PlayerDeathEvent event) {
+        if (handleEvent(Settings.EventType.DEATH_LISTENER, Settings.EventPriority.NORMAL)) {
+            handlePlayerDeath(event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    default void onPlayerDeathLowest(@NotNull PlayerDeathEvent event) {
+        if (handleEvent(Settings.EventType.DEATH_LISTENER, Settings.EventPriority.NORMAL)) {
+            handlePlayerDeath(event);
+        }
+    }
+
+    void handlePlayerDeath(@NotNull PlayerDeathEvent player);
+
+}

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitDeathEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitDeathEventListener.java
@@ -27,7 +27,7 @@ public interface BukkitDeathEventListener extends Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     default void onPlayerDeathLowest(@NotNull PlayerDeathEvent event) {
-        if (handleEvent(Settings.EventType.DEATH_LISTENER, Settings.EventPriority.NORMAL)) {
+        if (handleEvent(Settings.EventType.DEATH_LISTENER, Settings.EventPriority.LOWEST)) {
             handlePlayerDeath(event);
         }
     }

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -37,6 +37,7 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
 
     @Override
     public boolean handleEvent(@NotNull Settings.EventType type, @NotNull Settings.EventPriority priority) {
+        plugin.getLoggingAdapter().debug("Handling event " + type.name() + " with priority " + priority.name());
         return plugin.getSettings().getEventPriority(type).equals(priority);
     }
 

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitJoinEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitJoinEventListener.java
@@ -1,0 +1,38 @@
+package net.william278.husksync.listener;
+
+import net.william278.husksync.config.Settings;
+import net.william278.husksync.player.BukkitPlayer;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.jetbrains.annotations.NotNull;
+
+public interface BukkitJoinEventListener extends Listener {
+
+    boolean handleEvent(@NotNull Settings.EventType type, @NotNull Settings.EventPriority priority);
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    default void onPlayerJoinHighest(@NotNull PlayerJoinEvent event) {
+        if (handleEvent(Settings.EventType.JOIN_LISTENER, Settings.EventPriority.HIGHEST)) {
+            handlePlayerJoin(BukkitPlayer.adapt(event.getPlayer()));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    default void onPlayerJoin(@NotNull PlayerJoinEvent event) {
+        if (handleEvent(Settings.EventType.JOIN_LISTENER, Settings.EventPriority.NORMAL)) {
+            handlePlayerJoin(BukkitPlayer.adapt(event.getPlayer()));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    default void onPlayerJoinLowest(@NotNull PlayerJoinEvent event) {
+        if (handleEvent(Settings.EventType.JOIN_LISTENER, Settings.EventPriority.NORMAL)) {
+            handlePlayerJoin(BukkitPlayer.adapt(event.getPlayer()));
+        }
+    }
+
+    void handlePlayerJoin(@NotNull BukkitPlayer player);
+
+}

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitJoinEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitJoinEventListener.java
@@ -28,7 +28,7 @@ public interface BukkitJoinEventListener extends Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     default void onPlayerJoinLowest(@NotNull PlayerJoinEvent event) {
-        if (handleEvent(Settings.EventType.JOIN_LISTENER, Settings.EventPriority.NORMAL)) {
+        if (handleEvent(Settings.EventType.JOIN_LISTENER, Settings.EventPriority.LOWEST)) {
             handlePlayerJoin(BukkitPlayer.adapt(event.getPlayer()));
         }
     }

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitQuitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitQuitEventListener.java
@@ -1,0 +1,38 @@
+package net.william278.husksync.listener;
+
+import net.william278.husksync.config.Settings;
+import net.william278.husksync.player.BukkitPlayer;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.jetbrains.annotations.NotNull;
+
+public interface BukkitQuitEventListener extends Listener {
+
+    boolean handleEvent(@NotNull Settings.EventType type, @NotNull Settings.EventPriority priority);
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    default void onPlayerQuitHighest(@NotNull PlayerQuitEvent event) {
+        if (handleEvent(Settings.EventType.QUIT_LISTENER, Settings.EventPriority.HIGHEST)) {
+            handlePlayerQuit(BukkitPlayer.adapt(event.getPlayer()));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+    default void onPlayerQuit(@NotNull PlayerQuitEvent event) {
+        if (handleEvent(Settings.EventType.QUIT_LISTENER, Settings.EventPriority.NORMAL)) {
+            handlePlayerQuit(BukkitPlayer.adapt(event.getPlayer()));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    default void onPlayerQuitLowest(@NotNull PlayerQuitEvent event) {
+        if (handleEvent(Settings.EventType.QUIT_LISTENER, Settings.EventPriority.NORMAL)) {
+            handlePlayerQuit(BukkitPlayer.adapt(event.getPlayer()));
+        }
+    }
+
+    void handlePlayerQuit(@NotNull BukkitPlayer player);
+
+}

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitQuitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitQuitEventListener.java
@@ -28,7 +28,7 @@ public interface BukkitQuitEventListener extends Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     default void onPlayerQuitLowest(@NotNull PlayerQuitEvent event) {
-        if (handleEvent(Settings.EventType.QUIT_LISTENER, Settings.EventPriority.NORMAL)) {
+        if (handleEvent(Settings.EventType.QUIT_LISTENER, Settings.EventPriority.LOWEST)) {
             handlePlayerQuit(BukkitPlayer.adapt(event.getPlayer()));
         }
     }

--- a/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
@@ -46,9 +46,10 @@ public class EnderChestCommand extends CommandBase implements TabCompletable {
                                     "/enderchest <player> [version_uuid]").ifPresent(player::sendMessage);
                         }
                     } else {
-                        // View latest user data
+                        // View (and edit) the latest user data
                         plugin.getDatabase().getCurrentUserData(user).thenAccept(optionalData -> optionalData.ifPresentOrElse(
-                                versionedUserData -> showEnderChestMenu(player, versionedUserData, user, true),
+                                versionedUserData -> showEnderChestMenu(player, versionedUserData, user,
+                                        player.hasPermission(Permission.COMMAND_ENDER_CHEST_EDIT.node)),
                                 () -> plugin.getLocales().getLocale("error_no_data_to_display")
                                         .ifPresent(player::sendMessage)));
                     }

--- a/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
@@ -46,9 +46,10 @@ public class InventoryCommand extends CommandBase implements TabCompletable {
                                     "/inventory <player> [version_uuid]").ifPresent(player::sendMessage);
                         }
                     } else {
-                        // View latest user data
+                        // View (and edit) the latest user data
                         plugin.getDatabase().getCurrentUserData(user).thenAccept(optionalData -> optionalData.ifPresentOrElse(
-                                versionedUserData -> showInventoryMenu(player, versionedUserData, user, true),
+                                versionedUserData -> showInventoryMenu(player, versionedUserData, user,
+                                        player.hasPermission(Permission.COMMAND_INVENTORY_EDIT.node)),
                                 () -> plugin.getLocales().getLocale("error_no_data_to_display")
                                         .ifPresent(player::sendMessage)));
                     }

--- a/common/src/main/java/net/william278/husksync/config/Settings.java
+++ b/common/src/main/java/net/william278/husksync/config/Settings.java
@@ -143,7 +143,6 @@ public class Settings {
             return Map.entry(name().toLowerCase(), defaultName);
         }
 
-        @SuppressWarnings("unchecked")
         private static Map<String, String> getDefaults() {
             return Map.ofEntries(Arrays.stream(values())
                     .map(TableName::toEntry)
@@ -179,7 +178,6 @@ public class Settings {
             return Map.entry(name().toLowerCase(), enabledByDefault);
         }
 
-        @SuppressWarnings("unchecked")
         private static Map<String, Boolean> getDefaults() {
             return Map.ofEntries(Arrays.stream(values())
                     .map(SynchronizationFeature::toEntry)

--- a/common/src/main/java/net/william278/husksync/config/Settings.java
+++ b/common/src/main/java/net/william278/husksync/config/Settings.java
@@ -20,7 +20,7 @@ import java.util.Optional;
         ┣╸ Information: https://william278.net/project/husksync
         ┗╸ Documentation: https://william278.net/docs/husksync""",
 
-        versionField = "config_version", versionNumber = 2)
+        versionField = "config_version", versionNumber = 3)
 public class Settings {
 
     // Top-level settings
@@ -125,6 +125,15 @@ public class Settings {
                 .orElse(feature.enabledByDefault);
     }
 
+    @YamlKey("synchronization.event_priorities")
+    public Map<String, EventPriority> synchronizationEventPriorities = EventType.getDefaults();
+
+    @NotNull
+    public EventPriority getEventPriority(@NotNull Settings.EventType eventType) {
+        return Optional.ofNullable(synchronizationEventPriorities.get(eventType.name().toLowerCase()))
+                .orElse(EventPriority.NORMAL);
+    }
+
 
     /**
      * Represents the names of tables in the database
@@ -143,6 +152,7 @@ public class Settings {
             return Map.entry(name().toLowerCase(), defaultName);
         }
 
+        @SuppressWarnings("unchecked")
         private static Map<String, String> getDefaults() {
             return Map.ofEntries(Arrays.stream(values())
                     .map(TableName::toEntry)
@@ -178,11 +188,58 @@ public class Settings {
             return Map.entry(name().toLowerCase(), enabledByDefault);
         }
 
+
+        @SuppressWarnings("unchecked")
         private static Map<String, Boolean> getDefaults() {
             return Map.ofEntries(Arrays.stream(values())
                     .map(SynchronizationFeature::toEntry)
                     .toArray(Map.Entry[]::new));
         }
+    }
+
+    /**
+     * Represents events that HuskSync listens to, with a configurable priority listener
+     */
+    public enum EventType {
+        JOIN_LISTENER(EventPriority.LOWEST),
+        QUIT_LISTENER(EventPriority.LOWEST),
+        DEATH_LISTENER(EventPriority.NORMAL);
+
+        private final EventPriority defaultPriority;
+
+        EventType(@NotNull EventPriority defaultPriority) {
+            this.defaultPriority = defaultPriority;
+        }
+
+        private Map.Entry<String, EventPriority> toEntry() {
+            return Map.entry(name(), defaultPriority);
+        }
+
+
+        @SuppressWarnings("unchecked")
+        private static Map<String, EventPriority> getDefaults() {
+            return Map.ofEntries(Arrays.stream(values())
+                    .map(EventType::toEntry)
+                    .toArray(Map.Entry[]::new));
+        }
+    }
+
+    /**
+     * Represents priorities for events that HuskSync listens to
+     */
+    public enum EventPriority {
+        /**
+         * Listens and processes the event execution last
+         */
+        HIGHEST,
+        /**
+         * Listens in between {@link #HIGHEST} and {@link #LOWEST} priority marked
+         */
+        NORMAL,
+        /**
+         * Listens and processes the event execution first
+         */
+        LOWEST
     }
 
 }

--- a/common/src/main/java/net/william278/husksync/config/Settings.java
+++ b/common/src/main/java/net/william278/husksync/config/Settings.java
@@ -126,12 +126,16 @@ public class Settings {
     }
 
     @YamlKey("synchronization.event_priorities")
-    public Map<String, EventPriority> synchronizationEventPriorities = EventType.getDefaults();
+    public Map<String, String> synchronizationEventPriorities = EventType.getDefaults();
 
     @NotNull
     public EventPriority getEventPriority(@NotNull Settings.EventType eventType) {
-        return Optional.ofNullable(synchronizationEventPriorities.get(eventType.name().toLowerCase()))
-                .orElse(EventPriority.NORMAL);
+        try {
+            return EventPriority.valueOf(synchronizationEventPriorities.get(eventType.name().toLowerCase()));
+        } catch (IllegalArgumentException e) {
+            e.printStackTrace();
+            return EventPriority.NORMAL;
+        }
     }
 
 
@@ -211,13 +215,13 @@ public class Settings {
             this.defaultPriority = defaultPriority;
         }
 
-        private Map.Entry<String, EventPriority> toEntry() {
-            return Map.entry(name(), defaultPriority);
+        private Map.Entry<String, String> toEntry() {
+            return Map.entry(name().toLowerCase(), defaultPriority.name());
         }
 
 
         @SuppressWarnings("unchecked")
-        private static Map<String, EventPriority> getDefaults() {
+        private static Map<String, String> getDefaults() {
             return Map.ofEntries(Arrays.stream(values())
                     .map(EventType::toEntry)
                     .toArray(Map.Entry[]::new));

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
 javaVersion=16
 
-plugin_version=2.1.2
+plugin_version=2.1.3
 plugin_archive=husksync
 
 jedis_version=4.2.3


### PR DESCRIPTION
This PR adds a long-requested bit of functionality to support event priority configuration. This adds a new map field to the plugin configuration letting you change the priority between LOWEST, HIGHEST and NORMAL for three events.

Because bukkit requires specifying listener priority through annotations, which require a constant value, this approach is a _little_ bit clunky, but I tried to abstract it through some interfaces to keep things neat & tidy. 

Feedback and reviews welcome.