### PR TITLE
Sync lock: Cancel item frame interaction, add command blacklist

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -163,8 +163,8 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onPermissionCommand(PlayerCommandPreprocessEvent event) {
-        var commandArgs = event.getMessage().substring(1).split(" ");
-        var commandLabel = commandArgs[0].toLowerCase();
+        String[] commandArgs = event.getMessage().substring(1).split(" ");
+        String commandLabel = commandArgs[0].toLowerCase();
 
         if (blacklistedCommands.contains(commandLabel)) {
             event.setCancelled(cancelPlayerEvent(event.getPlayer().getUniqueId()));

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -161,7 +161,7 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
     }
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-    public void onPermissionCommand(PlayerCommandPreprocessEvent event) {
+    public void onPermissionCommand(@NotNull PlayerCommandPreprocessEvent event) {
         String[] commandArgs = event.getMessage().substring(1).split(" ");
         String commandLabel = commandArgs[0].toLowerCase();
 

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -1,6 +1,7 @@
 package net.william278.husksync.listener;
 
 import net.william278.husksync.BukkitHuskSync;
+import net.william278.husksync.api.HuskSyncAPI;
 import net.william278.husksync.config.Settings;
 import net.william278.husksync.data.BukkitInventoryMap;
 import net.william278.husksync.data.BukkitSerializer;
@@ -22,20 +23,25 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.world.WorldSaveEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
 public class BukkitEventListener extends EventListener implements BukkitJoinEventListener, BukkitQuitEventListener,
         BukkitDeathEventListener, Listener {
+    protected final List<String> blacklistedCommands;
 
     public BukkitEventListener(@NotNull BukkitHuskSync huskSync) {
         super(huskSync);
+        this.blacklistedCommands = huskSync.getSettings().blacklistedCommandsWhileLocked;
         Bukkit.getServer().getPluginManager().registerEvents(this, huskSync);
     }
 
@@ -122,6 +128,11 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerInteractEntity(@NotNull PlayerInteractEntityEvent event) {
+        event.setCancelled(cancelPlayerEvent(event.getPlayer().getUniqueId()));
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onBlockPlace(@NotNull BlockPlaceEvent event) {
         event.setCancelled(cancelPlayerEvent(event.getPlayer().getUniqueId()));
     }
@@ -147,6 +158,16 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
     public void onPlayerTakeDamage(@NotNull EntityDamageEvent event) {
         if (event.getEntity() instanceof Player player) {
             event.setCancelled(cancelPlayerEvent(player.getUniqueId()));
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onPermissionCommand(PlayerCommandPreprocessEvent event) {
+        var commandArgs = event.getMessage().substring(1).split(" ");
+        var commandLabel = commandArgs[0].toLowerCase();
+
+        if (blacklistedCommands.contains(commandLabel)) {
+            event.setCancelled(cancelPlayerEvent(event.getPlayer().getUniqueId()));
         }
     }
 

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -1,7 +1,6 @@
 package net.william278.husksync.listener;
 
 import net.william278.husksync.BukkitHuskSync;
-import net.william278.husksync.api.HuskSyncAPI;
 import net.william278.husksync.config.Settings;
 import net.william278.husksync.data.BukkitInventoryMap;
 import net.william278.husksync.data.BukkitSerializer;

--- a/common/src/main/java/net/william278/husksync/config/Settings.java
+++ b/common/src/main/java/net/william278/husksync/config/Settings.java
@@ -5,7 +5,9 @@ import net.william278.annotaml.YamlFile;
 import net.william278.annotaml.YamlKey;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -119,6 +121,9 @@ public class Settings {
 
     @YamlKey("synchronization.features")
     public Map<String, Boolean> synchronizationFeatures = SynchronizationFeature.getDefaults();
+
+    @YamlKey("synchronization.blacklisted_commands_while_locked")
+    public List<String> blacklistedCommandsWhileLocked = new ArrayList<>();
 
     public boolean getSynchronizationFeature(@NotNull SynchronizationFeature feature) {
         return synchronizationFeatures.getOrDefault(feature.name().toLowerCase(), feature.enabledByDefault);


### PR DESCRIPTION
…ds while sync

Players could duplicate items while being locked if they put their items in itemframes

Players also could duplicate items using commands from other plugins, an example would be zAuctionHouse, players could use `/ah sell 100` to put the item they are holding in the auction house then take it back once sync is done