### PR TITLE
Add additional cast checking to PDC tag fetching, cast via complex type

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitPersistentTypeMapping.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitPersistentTypeMapping.java
@@ -37,8 +37,8 @@ public record BukkitPersistentTypeMapping<T, Z>(PersistentDataTagType type, Pers
     }
 
     public void setContainerValue(@NotNull PersistentDataContainerData container, @NotNull Player player, @NotNull NamespacedKey key) throws NullPointerException {
-        container.getTagValue(key.toString(), bukkitType.getPrimitiveType())
-                .ifPresent(value -> player.getPersistentDataContainer().set(key, bukkitType, (Z) value));
+        container.getTagValue(key.toString(), bukkitType.getComplexType())
+                .ifPresent(value -> player.getPersistentDataContainer().set(key, bukkitType, value));
     }
 
     public static Optional<BukkitPersistentTypeMapping<?, ?>> getMapping(@NotNull PersistentDataTagType type) {

--- a/common/src/main/java/net/william278/husksync/data/PersistentDataContainerData.java
+++ b/common/src/main/java/net/william278/husksync/data/PersistentDataContainerData.java
@@ -18,7 +18,7 @@ public class PersistentDataContainerData {
     @SerializedName("persistent_data_map")
     protected Map<String, PersistentDataTag<?>> persistentDataMap;
 
-    public PersistentDataContainerData(@NotNull final Map<String, PersistentDataTag<?>> persistentDataMap) {
+    public PersistentDataContainerData(@NotNull Map<String, PersistentDataTag<?>> persistentDataMap) {
         this.persistentDataMap = persistentDataMap;
     }
 
@@ -26,15 +26,21 @@ public class PersistentDataContainerData {
     protected PersistentDataContainerData() {
     }
 
-
-    public <T> Optional<T> getTagValue(@NotNull final String tagName, @NotNull Class<T> tagClass) {
-        if (persistentDataMap.containsKey(tagName)) {
-            return Optional.of(tagClass.cast(persistentDataMap.get(tagName).value));
+    public <T> Optional<T> getTagValue(@NotNull String tagName, @NotNull Class<T> tagClass) {
+        if (!persistentDataMap.containsKey(tagName)) {
+            return Optional.empty();
         }
-        return Optional.empty();
+
+        // If the tag cannot be cast to the specified class, return an empty optional
+        final boolean canCast = tagClass.isAssignableFrom(persistentDataMap.get(tagName).value.getClass());
+        if (!canCast) {
+            return Optional.empty();
+        }
+
+        return Optional.of(tagClass.cast(persistentDataMap.get(tagName).value));
     }
 
-    public Optional<PersistentDataTagType> getTagType(@NotNull final String tagType) {
+    public Optional<PersistentDataTagType> getTagType(@NotNull String tagType) {
         if (persistentDataMap.containsKey(tagType)) {
             return PersistentDataTagType.getDataType(persistentDataMap.get(tagType).type);
         }


### PR DESCRIPTION
Makes a fix to how PDC tag types are fetched and casted. Adds additional cast-validity checking and casts to the complex rather than primitive type (latter of which was being used due to an oversight I believe)