### PR TITLE
Disable all projectiles while player is in sync

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -104,7 +104,7 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onProjectileLaunch(@NotNull ProjectileLaunchEvent event) {
         final Projectile projectile = event.getEntity();
-        if (projectile.getShooter() instanceof Player player && projectile.getType() == EntityType.TRIDENT) {
+        if (projectile.getShooter() instanceof Player player) {
             event.setCancelled(cancelPlayerEvent(player.getUniqueId()));
         }
     }


### PR DESCRIPTION
I've been facing a duplication problem with trident throwing, which has been fixed in a merged PR, and now I am facing another dup with experience bottles, so I decided to just cancel all projectiles thrown by a player while in sync