### PR TITLE
Add mariadb protocol option type

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
+++ b/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
@@ -124,7 +124,7 @@ public class BukkitHuskSync extends JavaPlugin implements HuskSync {
 
             // Prepare database connection
             this.database = new MySqlDatabase(this);
-            log(Level.INFO, "Attempting to establish connection to the database...");
+            log(Level.INFO, "Attempting to establish connection to the " + settings.getSqlType().getDisplayName() + " database...");
             initialized.set(this.database.initialize());
             if (initialized.get()) {
                 log(Level.INFO, "Successfully established a connection to the database");

--- a/common/src/main/java/net/william278/husksync/config/Settings.java
+++ b/common/src/main/java/net/william278/husksync/config/Settings.java
@@ -16,6 +16,7 @@ package net.william278.husksync.config;
 import net.william278.annotaml.YamlComment;
 import net.william278.annotaml.YamlFile;
 import net.william278.annotaml.YamlKey;
+import net.william278.husksync.database.Database;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -48,6 +49,10 @@ public class Settings {
 
 
     // Database settings
+    @YamlComment("Type of database to use (MYSQL, SQLITE)")
+    @YamlKey("database.type")
+    private Database.Type databaseType = Database.Type.MYSQL;
+    
     @YamlComment("Database connection settings")
     @YamlKey("database.credentials.host")
     private String mySqlHost = "localhost";
@@ -159,6 +164,12 @@ public class Settings {
 
     public boolean doDebugLogging() {
         return debugLogging;
+    }
+
+
+    @NotNull
+    public Database.Type getSqlType() {
+        return databaseType;
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/husksync/database/Database.java
+++ b/common/src/main/java/net/william278/husksync/database/Database.java
@@ -185,4 +185,30 @@ public abstract class Database {
      */
     public abstract void close();
 
+    /**
+     * Identifies types of databases
+     */
+    public enum Type {
+        MYSQL("MySQL", "mysql"),
+        MARIADB("MariaDB", "mariadb");
+
+        private final String displayName;
+        private final String protocol;
+
+        Type(@NotNull String displayName, @NotNull String protocol) {
+            this.displayName = displayName;
+            this.protocol = protocol;
+        }
+
+        @NotNull
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        @NotNull
+        public String getProtocol() {
+            return protocol;
+        }
+    }
+
 }

--- a/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
@@ -35,6 +35,11 @@ import java.util.logging.Level;
 public class MySqlDatabase extends Database {
 
     /**
+     * MySQL protocol
+     */
+    private final Database.Type type;
+
+    /**
      * MySQL server hostname
      */
     private final String mySqlHost;
@@ -68,6 +73,7 @@ public class MySqlDatabase extends Database {
     public MySqlDatabase(@NotNull HuskSync plugin) {
         super(plugin);
         final Settings settings = plugin.getSettings();
+        this.type = settings.getSqlType();
         this.mySqlHost = settings.getMySqlHost();
         this.mySqlPort = settings.getMySqlPort();
         this.mySqlDatabaseName = settings.getMySqlDatabase();
@@ -95,7 +101,7 @@ public class MySqlDatabase extends Database {
     public boolean initialize() {
         try {
             // Create jdbc driver connection url
-            final String jdbcUrl = "jdbc:mysql://" + mySqlHost + ":" + mySqlPort + "/" + mySqlDatabaseName + mySqlConnectionParameters;
+            final String jdbcUrl = "jdbc:" + type.getProtocol() + "://" + mySqlHost + ":" + mySqlPort + "/" + mySqlDatabaseName + mySqlConnectionParameters;
             connectionPool = new HikariDataSource();
             connectionPool.setJdbcUrl(jdbcUrl);
 


### PR DESCRIPTION
This PR will add support for mariadb protocols. The protocol will be inserted in the jdbc url as an alternative for mysql.

With MariaDB 11 the mysql connector is not compatible with mariadb anymore. It's not possible to use the mysql connector and mysql protocol with a MariaDB database anymroe.