### PR TITLE
Fix wrong timestamp/UUID being used for legacy conversion

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/util/BukkitLegacyConverter.java
+++ b/bukkit/src/main/java/net/william278/husksync/util/BukkitLegacyConverter.java
@@ -49,7 +49,7 @@ public class BukkitLegacyConverter extends LegacyConverter {
 
     @NotNull
     @Override
-    public DataSnapshot.Packed convert(@NotNull byte[] data) throws DataAdapter.AdaptionException {
+    public DataSnapshot.Packed convert(@NotNull UUID id, @NotNull byte[] data) throws DataAdapter.AdaptionException {
         final JSONObject object = new JSONObject(plugin.getDataAdapter().bytesToString(data));
         final int version = object.getInt("format_version");
         if (version != 3) {
@@ -61,6 +61,7 @@ public class BukkitLegacyConverter extends LegacyConverter {
 
         // Read legacy data from the JSON object
         final DataSnapshot.Builder builder = DataSnapshot.builder(plugin)
+                .id(id)
                 .saveCause(DataSnapshot.SaveCause.CONVERTED_FROM_V2)
                 .data(readStatusData(object));
         readInventory(object).ifPresent(builder::inventory);

--- a/bukkit/src/main/java/net/william278/husksync/util/BukkitLegacyConverter.java
+++ b/bukkit/src/main/java/net/william278/husksync/util/BukkitLegacyConverter.java
@@ -39,6 +39,7 @@ import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
 import java.io.ByteArrayInputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.time.OffsetDateTime;
 import java.util.*;
 
 public class BukkitLegacyConverter extends LegacyConverter {
@@ -49,7 +50,8 @@ public class BukkitLegacyConverter extends LegacyConverter {
 
     @NotNull
     @Override
-    public DataSnapshot.Packed convert(@NotNull UUID id, @NotNull byte[] data) throws DataAdapter.AdaptionException {
+    public DataSnapshot.Packed convert(@NotNull byte[] data, @NotNull UUID id,
+                                       @NotNull OffsetDateTime timestamp) throws DataAdapter.AdaptionException {
         final JSONObject object = new JSONObject(plugin.getDataAdapter().bytesToString(data));
         final int version = object.getInt("format_version");
         if (version != 3) {
@@ -61,7 +63,7 @@ public class BukkitLegacyConverter extends LegacyConverter {
 
         // Read legacy data from the JSON object
         final DataSnapshot.Builder builder = DataSnapshot.builder(plugin)
-                .id(id)
+                .id(id).timestamp(timestamp)
                 .saveCause(DataSnapshot.SaveCause.CONVERTED_FROM_V2)
                 .data(readStatusData(object));
         readInventory(object).ifPresent(builder::inventory);

--- a/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
+++ b/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
@@ -96,11 +96,11 @@ public class DataSnapshot {
         return new Builder(plugin);
     }
 
-    // Deserialize a DataSnapshot downloaded from the database (with an ID)
+    // Deserialize a DataSnapshot downloaded from the database (with an ID & Timestamp from the database)
     @NotNull
     @ApiStatus.Internal
-    public static DataSnapshot.Packed deserialize(@NotNull HuskSync plugin, @Nullable UUID id, byte[] data)
-            throws IllegalStateException {
+    public static DataSnapshot.Packed deserialize(@NotNull HuskSync plugin, byte[] data, @Nullable UUID id,
+                                                  @Nullable OffsetDateTime timestamp) throws IllegalStateException {
         final DataSnapshot.Packed snapshot = plugin.getDataAdapter().fromBytes(data, DataSnapshot.Packed.class);
         if (snapshot.getMinecraftVersion().compareTo(plugin.getMinecraftVersion()) > 0) {
             throw new IllegalStateException(String.format("Cannot set data for user because the Minecraft version of " +
@@ -137,7 +137,7 @@ public class DataSnapshot {
     @NotNull
     @ApiStatus.Internal
     public static DataSnapshot.Packed deserialize(@NotNull HuskSync plugin, byte[] data) throws IllegalStateException {
-        return deserialize(plugin, null, data);
+        return deserialize(plugin, data, null, null);
     }
 
     /**

--- a/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
+++ b/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
@@ -117,7 +117,9 @@ public class DataSnapshot {
         if (snapshot.getFormatVersion() < CURRENT_FORMAT_VERSION) {
             if (plugin.getLegacyConverter().isPresent()) {
                 return plugin.getLegacyConverter().get().convert(
-                        Objects.requireNonNull(id, "Attempted legacy conversion with null UUID!"), data
+                        data,
+                        Objects.requireNonNull(id, "Attempted legacy conversion with null UUID!"),
+                        Objects.requireNonNull(timestamp, "Attempted legacy conversion with null timestamp!")
                 );
             }
             throw new IllegalStateException(String.format(

--- a/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
@@ -217,7 +217,7 @@ public class MySqlDatabase extends Database {
     public Optional<DataSnapshot.Packed> getLatestSnapshot(@NotNull User user) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
-                    SELECT `version_uuid`, `timestamp`, `save_cause`, `pinned`, `data`
+                    SELECT `version_uuid`, `data`
                     FROM `%user_data_table%`
                     WHERE `player_uuid`=?
                     ORDER BY `timestamp` DESC
@@ -225,10 +225,11 @@ public class MySqlDatabase extends Database {
                 statement.setString(1, user.getUuid().toString());
                 final ResultSet resultSet = statement.executeQuery();
                 if (resultSet.next()) {
+                    final UUID versionUuid = UUID.fromString(resultSet.getString("version_uuid"));
                     final Blob blob = resultSet.getBlob("data");
                     final byte[] dataByteArray = blob.getBytes(1, (int) blob.length());
                     blob.free();
-                    return Optional.of(DataSnapshot.deserialize(plugin, dataByteArray));
+                    return Optional.of(DataSnapshot.deserialize(plugin, versionUuid, dataByteArray));
                 }
             }
         } catch (SQLException | DataAdapter.AdaptionException e) {
@@ -244,17 +245,18 @@ public class MySqlDatabase extends Database {
         final List<DataSnapshot.Packed> retrievedData = new ArrayList<>();
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
-                    SELECT `version_uuid`, `timestamp`, `save_cause`, `pinned`, `data`
+                    SELECT `version_uuid`, `data`
                     FROM `%user_data_table%`
                     WHERE `player_uuid`=?
                     ORDER BY `timestamp` DESC;"""))) {
                 statement.setString(1, user.getUuid().toString());
                 final ResultSet resultSet = statement.executeQuery();
                 while (resultSet.next()) {
+                    final UUID versionUuid = UUID.fromString(resultSet.getString("version_uuid"));
                     final Blob blob = resultSet.getBlob("data");
                     final byte[] dataByteArray = blob.getBytes(1, (int) blob.length());
                     blob.free();
-                    retrievedData.add(DataSnapshot.deserialize(plugin, dataByteArray));
+                    retrievedData.add(DataSnapshot.deserialize(plugin, versionUuid, dataByteArray));
                 }
                 return retrievedData;
             }
@@ -269,7 +271,7 @@ public class MySqlDatabase extends Database {
     public Optional<DataSnapshot.Packed> getSnapshot(@NotNull User user, @NotNull UUID versionUuid) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
-                    SELECT `version_uuid`, `timestamp`, `save_cause`, `pinned`, `data`
+                    SELECT `version_uuid`, `data`
                     FROM `%user_data_table%`
                     WHERE `player_uuid`=? AND `version_uuid`=?
                     ORDER BY `timestamp` DESC
@@ -281,7 +283,7 @@ public class MySqlDatabase extends Database {
                     final Blob blob = resultSet.getBlob("data");
                     final byte[] dataByteArray = blob.getBytes(1, (int) blob.length());
                     blob.free();
-                    return Optional.of(DataSnapshot.deserialize(plugin, dataByteArray));
+                    return Optional.of(DataSnapshot.deserialize(plugin, versionUuid, dataByteArray));
                 }
             }
         } catch (SQLException | DataAdapter.AdaptionException e) {

--- a/common/src/main/java/net/william278/husksync/util/LegacyConverter.java
+++ b/common/src/main/java/net/william278/husksync/util/LegacyConverter.java
@@ -24,6 +24,8 @@ import net.william278.husksync.adapter.DataAdapter;
 import net.william278.husksync.data.DataSnapshot;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.UUID;
+
 public abstract class LegacyConverter {
 
     protected final HuskSync plugin;
@@ -33,6 +35,6 @@ public abstract class LegacyConverter {
     }
 
     @NotNull
-    public abstract DataSnapshot.Packed convert(@NotNull byte[] data) throws DataAdapter.AdaptionException;
+    public abstract DataSnapshot.Packed convert(@NotNull UUID id, @NotNull byte[] data) throws DataAdapter.AdaptionException;
 
 }

--- a/common/src/main/java/net/william278/husksync/util/LegacyConverter.java
+++ b/common/src/main/java/net/william278/husksync/util/LegacyConverter.java
@@ -24,6 +24,7 @@ import net.william278.husksync.adapter.DataAdapter;
 import net.william278.husksync.data.DataSnapshot;
 import org.jetbrains.annotations.NotNull;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public abstract class LegacyConverter {
@@ -35,6 +36,7 @@ public abstract class LegacyConverter {
     }
 
     @NotNull
-    public abstract DataSnapshot.Packed convert(@NotNull UUID id, @NotNull byte[] data) throws DataAdapter.AdaptionException;
+    public abstract DataSnapshot.Packed convert(@NotNull byte[] data, @NotNull UUID id,
+                                                @NotNull OffsetDateTime timestamp) throws DataAdapter.AdaptionException;
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
 javaVersion=16
 
-plugin_version=3.0
+plugin_version=3.0.1
 plugin_archive=husksync
 plugin_description=A modern, cross-server player data synchronization system
 


### PR DESCRIPTION
Since the old format didn't store these in the data object itself these weren't being pulled and instead were getting randomised/set to the current timestamp, which meant they couldn't be edited or fetched. This fixes this.