### PR TITLE
Persist extra-terrestrial locked maps to disk

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -43,7 +43,9 @@ import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.server.MapInitializeEvent;
 import org.bukkit.event.world.WorldSaveEvent;
+import org.bukkit.map.MapView;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -113,6 +115,14 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
         plugin.runAsync(() -> super.saveOnWorldSave(event.getWorld().getPlayers()
                 .stream().map(player -> BukkitUser.adapt(player, plugin))
                 .collect(Collectors.toList())));
+    }
+
+    @EventHandler(ignoreCancelled = true)
+    public void onMapInitialize(@NotNull MapInitializeEvent event) {
+        final MapView view = event.getMap();
+        if (plugin.getSettings().doPersistLockedMaps() && view.isLocked() && view.getRenderers().isEmpty()) {
+            getPlugin().runAsync(() -> ((BukkitHuskSync) plugin).renderMapFromFile(event.getMap()));
+        }
     }
 
 

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -45,7 +45,6 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.server.MapInitializeEvent;
 import org.bukkit.event.world.WorldSaveEvent;
-import org.bukkit.map.MapView;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -119,8 +118,7 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
 
     @EventHandler(ignoreCancelled = true)
     public void onMapInitialize(@NotNull MapInitializeEvent event) {
-        final MapView view = event.getMap();
-        if (plugin.getSettings().doPersistLockedMaps() && view.isLocked() && view.getRenderers().isEmpty()) {
+        if (plugin.getSettings().doPersistLockedMaps() && event.getMap().isLocked()) {
             getPlugin().runAsync(() -> ((BukkitHuskSync) plugin).renderMapFromFile(event.getMap()));
         }
     }

--- a/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
+++ b/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
@@ -36,6 +36,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
+import java.io.File;
 import java.util.List;
 import java.util.*;
 import java.util.function.Function;
@@ -175,11 +176,12 @@ public interface BukkitMapPersister {
                 return;
             }
 
-            // Add a renderer to the map with the data
+            // Add a renderer to the map with the data and save to file
             final MapView view = generateRenderedMap(canvasData);
             final String worldUid = getDefaultMapWorld().getUID().toString();
             meta.setMapView(view);
             map.setItemMeta(meta);
+            saveMapToFile(canvasData, view.getId());
 
             // Set the map view ID in NBT
             NBT.modify(map, editable -> {
@@ -190,6 +192,58 @@ public interface BukkitMapPersister {
             getPlugin().debug(String.format("Generated view (#%s) and updated map (UID: %s)", view.getId(), worldUid));
         });
         return map;
+    }
+
+    default void renderMapFromFile(@NotNull MapView view) {
+        final File mapFile = new File(getMapCacheFolder(), view.getId() + ".dat");
+        if (!mapFile.exists()) {
+            return;
+        }
+
+        final MapData canvasData;
+        try {
+            canvasData = MapData.fromNbt(mapFile);
+        } catch (Throwable e) {
+            getPlugin().log(Level.WARNING, "Failed to deserialize map data from file", e);
+            return;
+        }
+
+        getPlugin().runSync(() -> {
+            // Create a new map view renderer with the map data color at each pixel
+            view.getRenderers().clear();
+            view.addRenderer(new PersistentMapRenderer(canvasData));
+            view.setLocked(true);
+            view.setScale(MapView.Scale.NORMAL);
+            view.setTrackingPosition(false);
+            view.setUnlimitedTracking(false);
+
+            // Set the view to the map
+            setMapView(view);
+        });
+    }
+
+    default void saveMapToFile(@NotNull MapData data, int id) {
+        getPlugin().runAsync(() -> {
+            final File mapFile = new File(getMapCacheFolder(), id + ".dat");
+            if (mapFile.exists()) {
+                return;
+            }
+
+            try {
+                data.toFile(mapFile);
+            } catch (Throwable e) {
+                getPlugin().log(Level.WARNING, "Failed to serialize map data to file", e);
+            }
+        });
+    }
+
+    @NotNull
+    private File getMapCacheFolder() {
+        final File mapCache = new File(getPlugin().getDataFolder(), "maps");
+        if (!mapCache.exists() && !mapCache.mkdirs()) {
+            getPlugin().log(Level.WARNING, "Failed to create maps folder");
+        }
+        return mapCache;
     }
 
     // Sets the renderer of a map, and returns the generated MapView

--- a/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
+++ b/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
@@ -210,18 +210,16 @@ public interface BukkitMapPersister {
             return;
         }
 
-        getPlugin().runSync(() -> {
-            // Create a new map view renderer with the map data color at each pixel
-            view.getRenderers().clear();
-            view.addRenderer(new PersistentMapRenderer(canvasData));
-            view.setLocked(true);
-            view.setScale(MapView.Scale.NORMAL);
-            view.setTrackingPosition(false);
-            view.setUnlimitedTracking(false);
+        // Create a new map view renderer with the map data color at each pixel
+        view.getRenderers().clear();
+        view.addRenderer(new PersistentMapRenderer(canvasData));
+        view.setLocked(true);
+        view.setScale(MapView.Scale.NORMAL);
+        view.setTrackingPosition(false);
+        view.setUnlimitedTracking(false);
 
-            // Set the view to the map
-            setMapView(view);
-        });
+        // Set the view to the map
+        setMapView(view);
     }
 
     default void saveMapToFile(@NotNull MapData data, int id) {

--- a/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
+++ b/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
@@ -22,6 +22,8 @@ package net.william278.husksync.util;
 import de.tr7zw.changeme.nbtapi.NBT;
 import de.tr7zw.changeme.nbtapi.iface.ReadWriteNBT;
 import de.tr7zw.changeme.nbtapi.iface.ReadableNBT;
+import net.querz.nbt.io.NBTUtil;
+import net.querz.nbt.tag.CompoundTag;
 import net.william278.husksync.HuskSync;
 import net.william278.mapdataapi.MapBanner;
 import net.william278.mapdataapi.MapData;
@@ -230,7 +232,9 @@ public interface BukkitMapPersister {
             }
 
             try {
-                data.toFile(mapFile);
+                final CompoundTag rootTag = new CompoundTag();
+                rootTag.put("data", data.toNBT().getTag());
+                NBTUtil.write(rootTag, mapFile);
             } catch (Throwable e) {
                 getPlugin().log(Level.WARNING, "Failed to serialize map data to file", e);
             }


### PR DESCRIPTION
Closes #157

The plugin will now cache maps from other servers to disk in the `plugins/HuskSync/maps` folder. This allows maps that aren't in player inventories - such as those in item frame displays - to be automatically loaded when the map is initialized (e.g. when the chunk loads) by asynchronously loading the map from file.