### PR TITLE
feat: add ProtocolLib support for deeper-level packet cancellation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ allprojects {
         mavenLocal()
         mavenCentral()
         maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
+        maven { url "https://repo.dmulloy2.net/repository/public/" }
         maven { url 'https://repo.codemc.io/repository/maven-public/' }
         maven { url 'https://repo.minebench.de/' }
         maven { url 'https://repo.alessiodp.com/releases/' }

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation 'de.tr7zw:item-nbt-api:2.12.3'
 
     compileOnly 'org.spigotmc:spigot-api:1.17.1-R0.1-SNAPSHOT'
+    compileOnly 'com.comphenix.protocol:ProtocolLib:5.1.0'
     compileOnly 'org.projectlombok:lombok:1.18.32'
     compileOnly 'commons-io:commons-io:2.16.0'
     compileOnly 'org.json:json:20240303'

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -24,41 +24,35 @@ import net.william278.husksync.HuskSync;
 import net.william278.husksync.data.BukkitData;
 import net.william278.husksync.user.BukkitUser;
 import net.william278.husksync.user.OnlineUser;
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Projectile;
-import org.bukkit.event.Cancellable;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
-import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.entity.ProjectileLaunchEvent;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryOpenEvent;
-import org.bukkit.event.inventory.PrepareItemCraftEvent;
-import org.bukkit.event.player.*;
 import org.bukkit.event.server.MapInitializeEvent;
 import org.bukkit.event.world.WorldSaveEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class BukkitEventListener extends EventListener implements BukkitJoinEventListener, BukkitQuitEventListener,
         BukkitDeathEventListener, Listener {
-    protected final List<String> blacklistedCommands;
 
-    public BukkitEventListener(@NotNull BukkitHuskSync huskSync) {
-        super(huskSync);
-        this.blacklistedCommands = huskSync.getSettings().getSynchronization().getBlacklistedCommandsWhileLocked();
-        Bukkit.getServer().getPluginManager().registerEvents(this, huskSync);
+    private final LockedHandler lockedHandler;
+
+    public BukkitEventListener(@NotNull BukkitHuskSync plugin) {
+        super(plugin);
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+        this.lockedHandler = createLockedHandler(plugin);
+    }
+
+    @NotNull
+    private LockedHandler createLockedHandler(@NotNull BukkitHuskSync plugin) {
+        if (getPlugin().isDependencyLoaded("ProtocolLib") && getPlugin().getSettings().isCancelPackets()) {
+            return new BukkitLockedPacketListener(plugin);
+        } else {
+            return new BukkitLockedEventListener(plugin);
+        }
     }
 
     @Override
@@ -88,7 +82,7 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
         final OnlineUser user = BukkitUser.adapt(event.getEntity(), plugin);
 
         // If the player is locked or the plugin disabling, clear their drops
-        if (cancelPlayerEvent(user.getUuid())) {
+        if (lockedHandler.cancelPlayerEvent(user.getUuid())) {
             event.getDrops().clear();
             return;
         }
@@ -122,95 +116,6 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
     public void onMapInitialize(@NotNull MapInitializeEvent event) {
         if (plugin.getSettings().getSynchronization().isPersistLockedMaps() && event.getMap().isLocked()) {
             getPlugin().runAsync(() -> ((BukkitHuskSync) plugin).renderMapFromFile(event.getMap()));
-        }
-    }
-
-
-    /*
-     * Events to cancel if the player has not been set yet
-     */
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onProjectileLaunch(@NotNull ProjectileLaunchEvent event) {
-        final Projectile projectile = event.getEntity();
-        if (projectile.getShooter() instanceof Player player) {
-            cancelPlayerEvent(player.getUniqueId(), event);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onDropItem(@NotNull PlayerDropItemEvent event) {
-        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onPickupItem(@NotNull EntityPickupItemEvent event) {
-        if (event.getEntity() instanceof Player player) {
-            cancelPlayerEvent(player.getUniqueId(), event);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onPlayerInteract(@NotNull PlayerInteractEvent event) {
-        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onPlayerInteractEntity(@NotNull PlayerInteractEntityEvent event) {
-        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onPlayerInteractArmorStand(@NotNull PlayerArmorStandManipulateEvent event) {
-        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onBlockPlace(@NotNull BlockPlaceEvent event) {
-        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onBlockBreak(@NotNull BlockBreakEvent event) {
-        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onInventoryOpen(@NotNull InventoryOpenEvent event) {
-        if (event.getPlayer() instanceof Player player) {
-            cancelPlayerEvent(player.getUniqueId(), event);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onInventoryClick(@NotNull InventoryClickEvent event) {
-        cancelPlayerEvent(event.getWhoClicked().getUniqueId(), event);
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onCraftItem(@NotNull PrepareItemCraftEvent event) {
-    }
-
-    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
-    public void onPlayerTakeDamage(@NotNull EntityDamageEvent event) {
-        if (event.getEntity() instanceof Player player) {
-            cancelPlayerEvent(player.getUniqueId(), event);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-    public void onPermissionCommand(@NotNull PlayerCommandPreprocessEvent event) {
-        final String[] commandArgs = event.getMessage().substring(1).split(" ");
-        final String commandLabel = commandArgs[0].toLowerCase(Locale.ENGLISH);
-
-        if (blacklistedCommands.contains("*") || blacklistedCommands.contains(commandLabel)) {
-            cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
-        }
-    }
-
-    private void cancelPlayerEvent(@NotNull UUID uuid, @NotNull Cancellable event) {
-        if (cancelPlayerEvent(uuid)) {
-            event.setCancelled(true);
         }
     }
 

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -26,8 +26,10 @@ import net.william278.husksync.user.BukkitUser;
 import net.william278.husksync.user.OnlineUser;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 import org.bukkit.event.server.MapInitializeEvent;
 import org.bukkit.event.world.WorldSaveEvent;
 import org.bukkit.inventory.ItemStack;
@@ -116,6 +118,17 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
     public void onMapInitialize(@NotNull MapInitializeEvent event) {
         if (plugin.getSettings().getSynchronization().isPersistLockedMaps() && event.getMap().isLocked()) {
             getPlugin().runAsync(() -> ((BukkitHuskSync) plugin).renderMapFromFile(event.getMap()));
+        }
+    }
+
+    // We handle commands here to allow specific command handling on ProtocolLib servers
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onCommandProcessed(@NotNull PlayerCommandPreprocessEvent event) {
+        if (!lockedHandler.isCommandDisabled(event.getMessage().substring(1).split(" ")[0])) {
+            return;
+        }
+        if (lockedHandler.cancelPlayerEvent(event.getPlayer().getUniqueId())) {
+            event.setCancelled(true);
         }
     }
 

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedEventListener.java
@@ -1,0 +1,115 @@
+package net.william278.husksync.listener;
+
+import lombok.Getter;
+import net.william278.husksync.BukkitHuskSync;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityPickupItemEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.event.player.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+@Getter
+public class BukkitLockedEventListener implements LockedHandler, Listener {
+
+    private final BukkitHuskSync plugin;
+
+    protected BukkitLockedEventListener(@NotNull BukkitHuskSync plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onProjectileLaunch(@NotNull ProjectileLaunchEvent event) {
+        final Projectile projectile = event.getEntity();
+        if (projectile.getShooter() instanceof Player player) {
+            cancelPlayerEvent(player.getUniqueId(), event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onDropItem(@NotNull PlayerDropItemEvent event) {
+        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPickupItem(@NotNull EntityPickupItemEvent event) {
+        if (event.getEntity() instanceof Player player) {
+            cancelPlayerEvent(player.getUniqueId(), event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerInteract(@NotNull PlayerInteractEvent event) {
+        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerInteractEntity(@NotNull PlayerInteractEntityEvent event) {
+        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerInteractArmorStand(@NotNull PlayerArmorStandManipulateEvent event) {
+        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBlockPlace(@NotNull BlockPlaceEvent event) {
+        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onBlockBreak(@NotNull BlockBreakEvent event) {
+        cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onInventoryOpen(@NotNull InventoryOpenEvent event) {
+        if (event.getPlayer() instanceof Player player) {
+            cancelPlayerEvent(player.getUniqueId(), event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onInventoryClick(@NotNull InventoryClickEvent event) {
+        cancelPlayerEvent(event.getWhoClicked().getUniqueId(), event);
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onCraftItem(@NotNull PrepareItemCraftEvent event) {
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
+    public void onPlayerTakeDamage(@NotNull EntityDamageEvent event) {
+        if (event.getEntity() instanceof Player player) {
+            cancelPlayerEvent(player.getUniqueId(), event);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onPermissionCommand(@NotNull PlayerCommandPreprocessEvent event) {
+        if (isCommandDisabled(event.getMessage().substring(1).split(" ")[0])) {
+            cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
+        }
+    }
+
+    private void cancelPlayerEvent(@NotNull UUID uuid, @NotNull Cancellable event) {
+        if (cancelPlayerEvent(uuid)) {
+            event.setCancelled(true);
+        }
+    }
+
+}

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedEventListener.java
@@ -16,7 +16,10 @@ import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
-import org.bukkit.event.player.*;
+import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
+import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.UUID;
@@ -96,13 +99,6 @@ public class BukkitLockedEventListener implements LockedHandler, Listener {
     public void onPlayerTakeDamage(@NotNull EntityDamageEvent event) {
         if (event.getEntity() instanceof Player player) {
             cancelPlayerEvent(player.getUniqueId(), event);
-        }
-    }
-
-    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
-    public void onPermissionCommand(@NotNull PlayerCommandPreprocessEvent event) {
-        if (isCommandDisabled(event.getMessage().substring(1).split(" ")[0])) {
-            cancelPlayerEvent(event.getPlayer().getUniqueId(), event);
         }
     }
 

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedPacketListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedPacketListener.java
@@ -13,7 +13,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Set;
 import java.util.logging.Level;
 
-import static com.comphenix.protocol.PacketType.Play.*;
+import static com.comphenix.protocol.PacketType.Play.Server;
 
 @Getter
 public class BukkitLockedPacketListener implements LockedHandler {
@@ -29,9 +29,11 @@ public class BukkitLockedPacketListener implements LockedHandler {
     @Getter
     private static class PlayerPacketAdapter extends PacketAdapter {
 
-        private static final Set<PacketType> ALLOWED_TYPES = Set.of(
-                Server.KEEP_ALIVE, Server.LOGIN, Server.KICK_DISCONNECT, Server.RESPAWN,
-                Server.PLAYER_LIST_HEADER_FOOTER, Server.PLAYER_INFO, Server.PLAYER_INFO_REMOVE
+        // Packets we want the player to still be able to SEND to the server
+        private static final Set<PacketType> ALLOWED_PACKETS = Set.of(
+                Server.KEEP_ALIVE, Server.LOGIN, Server.KICK_DISCONNECT, // Connection packets are OK
+                Server.PLAYER_LIST_HEADER_FOOTER, Server.PLAYER_INFO, Server.PLAYER_INFO_REMOVE, // TAB stuff is OK
+                Server.COMMANDS // Handled elsewhere
         );
 
         private final BukkitLockedPacketListener listener;
@@ -48,9 +50,10 @@ public class BukkitLockedPacketListener implements LockedHandler {
             }
         }
 
+        // Returns the set of ALL Server packets, excluding the set of allowed packets
         @NotNull
         private static Set<PacketType> getPacketsToListenFor() {
-            return Sets.difference(Server.getInstance().values(), ALLOWED_TYPES);
+            return Sets.difference(Server.getInstance().values(), ALLOWED_PACKETS);
         }
 
     }

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedPacketListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedPacketListener.java
@@ -1,0 +1,58 @@
+package net.william278.husksync.listener;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.google.common.collect.Sets;
+import lombok.Getter;
+import net.william278.husksync.BukkitHuskSync;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Set;
+import java.util.logging.Level;
+
+import static com.comphenix.protocol.PacketType.Play.*;
+
+@Getter
+public class BukkitLockedPacketListener implements LockedHandler {
+
+    private final BukkitHuskSync plugin;
+
+    protected BukkitLockedPacketListener(@NotNull BukkitHuskSync plugin) {
+        this.plugin = plugin;
+        ProtocolLibrary.getProtocolManager().addPacketListener(new PlayerPacketAdapter(this));
+        plugin.log(Level.INFO, "Using ProtocolLib to cancel packets for locked players");
+    }
+
+    @Getter
+    private static class PlayerPacketAdapter extends PacketAdapter {
+
+        private static final Set<PacketType> ALLOWED_TYPES = Set.of(
+                Server.KEEP_ALIVE, Server.LOGIN, Server.KICK_DISCONNECT, Server.RESPAWN,
+                Server.PLAYER_LIST_HEADER_FOOTER, Server.PLAYER_INFO, Server.PLAYER_INFO_REMOVE
+        );
+
+        private final BukkitLockedPacketListener listener;
+
+        public PlayerPacketAdapter(@NotNull BukkitLockedPacketListener listener) {
+            super(listener.getPlugin(), ListenerPriority.HIGHEST, getPacketsToListenFor());
+            this.listener = listener;
+        }
+
+        @Override
+        public void onPacketSending(@NotNull PacketEvent event) {
+            if (listener.cancelPlayerEvent(event.getPlayer().getUniqueId())) {
+                event.setCancelled(true);
+            }
+        }
+
+        @NotNull
+        private static Set<PacketType> getPacketsToListenFor() {
+            return Sets.difference(Server.getInstance().values(), ALLOWED_TYPES);
+        }
+
+    }
+
+}

--- a/bukkit/src/main/resources/plugin.yml
+++ b/bukkit/src/main/resources/plugin.yml
@@ -6,6 +6,7 @@ author: 'William278'
 description: '${description}'
 website: 'https://william278.net'
 softdepend:
+  - 'ProtocolLib'
   - 'MysqlPlayerDataBridge'
   - 'Plan'
 libraries:

--- a/common/src/main/java/net/william278/husksync/config/Locales.java
+++ b/common/src/main/java/net/william278/husksync/config/Locales.java
@@ -57,7 +57,7 @@ public class Locales {
     Map<String, String> locales = Maps.newTreeMap();
 
     /**
-     * Returns a raw, un-formatted locale loaded from the locales file
+     * Returns a raw, unformatted locale loaded from the locale file
      *
      * @param localeId String identifier of the locale, corresponding to a key in the file
      * @return An {@link Optional} containing the locale corresponding to the id, if it exists

--- a/common/src/main/java/net/william278/husksync/config/Settings.java
+++ b/common/src/main/java/net/william278/husksync/config/Settings.java
@@ -75,6 +75,9 @@ public class Settings {
     @Comment({"Whether to enable the Player Analytics hook.", "Docs: https://william278.net/docs/husksync/plan-hook"})
     private boolean enablePlanHook = true;
 
+    @Comment("Whether to cancel game event packets directly when handling locked players if ProtocolLib is installed")
+    private boolean cancelPackets = true;
+
 
     // Database settings
     @Comment("Database settings")

--- a/common/src/main/java/net/william278/husksync/listener/EventListener.java
+++ b/common/src/main/java/net/william278/husksync/listener/EventListener.java
@@ -28,7 +28,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static net.william278.husksync.config.Settings.SynchronizationSettings.SaveOnDeathSettings;
 
@@ -104,15 +103,6 @@ public abstract class EventListener {
         plugin.getDataSyncer().saveData(user, snapshot);
     }
 
-    /**
-     * Determine whether a player event should be canceled
-     *
-     * @param userUuid The UUID of the user to check
-     * @return Whether the event should be canceled
-     */
-    protected final boolean cancelPlayerEvent(@NotNull UUID userUuid) {
-        return plugin.isDisabling() || plugin.isLocked(userUuid);
-    }
 
     /**
      * Handle the plugin disabling

--- a/common/src/main/java/net/william278/husksync/listener/LockedHandler.java
+++ b/common/src/main/java/net/william278/husksync/listener/LockedHandler.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of HuskSync, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.husksync.listener;
+
+import net.william278.husksync.HuskSync;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Interface for doing stuff with locked users or when the plugin is disabled
+ */
+public interface LockedHandler {
+
+    /**
+     * Get if a command should be disabled while the user is locked
+     */
+    default boolean isCommandDisabled(@NotNull String label) {
+        if (label.trim().equalsIgnoreCase("*")) {
+            return true;
+        }
+        return getPlugin().getSettings().getSynchronization().getBlacklistedCommandsWhileLocked()
+                .contains(label.toLowerCase(Locale.ENGLISH));
+    }
+
+    /**
+     * Determine whether a player event should be canceled
+     *
+     * @param userUuid The UUID of the user to check
+     * @return Whether the event should be canceled
+     */
+    default boolean cancelPlayerEvent(@NotNull UUID userUuid) {
+        return getPlugin().isDisabling() || getPlugin().isLocked(userUuid);
+    }
+
+    @NotNull
+    @ApiStatus.Internal
+    HuskSync getPlugin();
+
+}

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -11,10 +11,11 @@ This will walk you through installing HuskSync on your network of Spigot servers
 ### 1. Install the jar
 - Place the plugin jar file in the `/plugins/` directory of each Spigot server.
 - You do not need to install HuskSync as a proxy plugin.
+- You can additionally install [ProtocolLib](https://www.spigotmc.org/resources/protocollib.1997/) for better locked user handling, and [Plan](https://www.spigotmc.org/resources/plan-player-analytics.32536/) for analytics.
 ### 2. Restart servers
 - Start, then stop every server to let HuskSync generate the [[config file]].
 - HuskSync will throw an error in the console and disable itself as it is unable to connect to the database. You haven't set the credentials yet, so this is expected.
-- Advanced users: If you'd prefer, you can just create one config.yml file and create symbolic links in each `/plugins/HuskSync/` folder to it to make updating it easier.
+- Advanced users: If you'd prefer, you can create one config.yml file and create symbolic links in each `/plugins/HuskSync/` folder to it to make updating it easier.
 ### 3. Enter Mysql & Redis database credentials
 - Navigate to the HuskSync config file on each server (`~/plugins/HuskSync/config.yml`)
 - Under `credentials` in the `database` section, enter the credentials of your (MySQL/MariaDB/MongoDB/PostgreSQL) Database. You shouldn't touch the `connection_pool` properties.

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -12,23 +12,27 @@ This will walk you through installing HuskSync on your network of Spigot servers
 - Place the plugin jar file in the `/plugins/` directory of each Spigot server.
 - You do not need to install HuskSync as a proxy plugin.
 - You can additionally install [ProtocolLib](https://www.spigotmc.org/resources/protocollib.1997/) for better locked user handling, and [Plan](https://www.spigotmc.org/resources/plan-player-analytics.32536/) for analytics.
+
 ### 2. Restart servers
 - Start, then stop every server to let HuskSync generate the [[config file]].
 - HuskSync will throw an error in the console and disable itself as it is unable to connect to the database. You haven't set the credentials yet, so this is expected.
 - Advanced users: If you'd prefer, you can create one config.yml file and create symbolic links in each `/plugins/HuskSync/` folder to it to make updating it easier.
+
 ### 3. Enter Mysql & Redis database credentials
 - Navigate to the HuskSync config file on each server (`~/plugins/HuskSync/config.yml`)
 - Under `credentials` in the `database` section, enter the credentials of your (MySQL/MariaDB/MongoDB/PostgreSQL) Database. You shouldn't touch the `connection_pool` properties.
 - Under `credentials` in the `redis` section, enter the credentials of your Redis Database. If your Redis server doesn't have a password, leave the password blank as it is.
 - Unless you want to have multiple clusters of servers within your network, each with separate user data, you should not change the value of `cluster_id`.
+
 <details>
-<summary><b>For MongoDB Users</b></summary>
+<summary>Important &mdash; MongoDB Users</summary>
 
 - Navigate to the HuskSync config file on each server (`~/plugins/HuskSync/config.yml`)
 - Set `type` in the `database` section to `MONGO`
 - Under `credentials` in the `database` section, enter the credentials of your MongoDB Database. You shouldn't touch the `connection_pool` properties.
 <details>
-<summary><b>MongoDB Atlas</b></summary>
+
+<summary>Additional configuration for MongoDB Atlas users</summary>
 
 - Navigate to the HuskSync config file on each server (`~/plugins/HuskSync/config.yml`)
 - Set `using_atlas` in the `mongo_settings` section to `true`. 
@@ -42,6 +46,7 @@ This will walk you through installing HuskSync on your network of Spigot servers
 ### 4. Set server names in server.yml files
 - Navigate to the HuskSync server name file on each server (`~/plugins/HuskSync/server.yml`)
 - Set the `name:` of the server in this file to the ID of this server as defined in the config of your proxy (e.g., if this is the "hub" server you access with `/server hub`, put `'hub'` here)
+
 ### 5. Start every server again
 - Provided your MySQL and Redis credentials were correct, synchronization should begin as soon as you start your servers again.
 - If you need to import data from HuskSync v1.x or MySQLPlayerDataBridge, please see the guides below:

--- a/paper/src/main/resources/paper-plugin.yml
+++ b/paper/src/main/resources/paper-plugin.yml
@@ -8,6 +8,10 @@ version: '${version}'
 api-version: '1.19'
 dependencies:
   server:
+    ProtocolLib:
+      required: false
+      load: BEFORE
+      join-classpath: true
     MysqlPlayerDataBridge:
       required: false
       load: BEFORE


### PR DESCRIPTION
Adds optional support for ProtocolLib for improved packet handling of locked users, if installed. Can be turned off with a new config setting.

Basically just a better security measure against very extreme locked-user edge case exploits, or servers that do lots of funky stuff.