### PR TITLE
feat: Add attribute syncing

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
+++ b/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
@@ -143,6 +143,7 @@ public class BukkitHuskSync extends JavaPlugin implements HuskSync, BukkitTask.S
             registerSerializer(Identifier.LOCATION, new BukkitSerializer.Location(this));
             registerSerializer(Identifier.HEALTH, new BukkitSerializer.Json<>(this, BukkitData.Health.class));
             registerSerializer(Identifier.HUNGER, new BukkitSerializer.Json<>(this, BukkitData.Hunger.class));
+            registerSerializer(Identifier.ATTRIBUTES, new BukkitSerializer.Json<>(this, BukkitData.Attributes.class));
             registerSerializer(Identifier.GAME_MODE, new BukkitSerializer.Json<>(this, BukkitData.GameMode.class));
             registerSerializer(Identifier.FLIGHT_STATUS, new BukkitSerializer.Json<>(this, BukkitData.FlightStatus.class));
             registerSerializer(Identifier.POTION_EFFECTS, new BukkitSerializer.PotionEffects(this));

--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
@@ -682,8 +682,8 @@ public abstract class BukkitData implements Data {
             final List<Attribute> attributes = Lists.newArrayList();
             Registry.ATTRIBUTE.forEach(id -> {
                 final AttributeInstance instance = player.getAttribute(id);
-                if (instance == null) {
-                    return;
+                if (instance == null || instance.getValue() == instance.getDefaultValue()) {
+                    return; // We don't sync unmodified attributes
                 }
                 attributes.add(adapt(instance));
             });

--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
@@ -699,7 +699,7 @@ public abstract class BukkitData implements Data {
             return new Attribute(
                     instance.getAttribute().getKey().toString(),
                     instance.getBaseValue(),
-                    instance.getModifiers().stream().map(BukkitData.Attributes::adapt).toList()
+                    instance.getModifiers().stream().map(BukkitData.Attributes::adapt).collect(Collectors.toSet())
             );
         }
 

--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitUserDataHolder.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitUserDataHolder.java
@@ -41,6 +41,7 @@ public interface BukkitUserDataHolder extends UserDataHolder {
                 case "statistics" -> getStatistics();
                 case "health" -> getHealth();
                 case "hunger" -> getHunger();
+                case "attributes" -> getAttributes();
                 case "experience" -> getExperience();
                 case "game_mode" -> getGameMode();
                 case "flight_status" -> getFlightStatus();
@@ -115,6 +116,12 @@ public interface BukkitUserDataHolder extends UserDataHolder {
     @Override
     default Optional<Data.Hunger> getHunger() {
         return Optional.of(BukkitData.Hunger.adapt(getBukkitPlayer()));
+    }
+
+    @NotNull
+    @Override
+    default Optional<Data.Attributes> getAttributes() {
+        return Optional.of(BukkitData.Attributes.adapt(getBukkitPlayer()));
     }
 
     @NotNull

--- a/bukkit/src/main/java/net/william278/husksync/migrator/LegacyMigrator.java
+++ b/bukkit/src/main/java/net/william278/husksync/migrator/LegacyMigrator.java
@@ -331,7 +331,7 @@ public class LegacyMigrator extends Migrator {
                                 )))
 
                         // Health, hunger, experience & game mode
-                        .health(BukkitData.Health.from(health, maxHealth, healthScale))
+                        .health(BukkitData.Health.from(health, healthScale))
                         .hunger(BukkitData.Hunger.from(hunger, saturation, saturationExhaustion))
                         .experience(BukkitData.Experience.from(totalExp, expLevel, expProgress))
                         .gameMode(BukkitData.GameMode.from(gameMode))

--- a/bukkit/src/main/java/net/william278/husksync/util/BukkitLegacyConverter.java
+++ b/bukkit/src/main/java/net/william278/husksync/util/BukkitLegacyConverter.java
@@ -87,7 +87,6 @@ public class BukkitLegacyConverter extends LegacyConverter {
         if (shouldImport(Identifier.HEALTH)) {
             containers.put(Identifier.HEALTH, BukkitData.Health.from(
                     status.getDouble("health"),
-                    status.getDouble("max_health"),
                     status.getDouble("health_scale")
             ));
         }

--- a/common/src/main/java/net/william278/husksync/HuskSync.java
+++ b/common/src/main/java/net/william278/husksync/HuskSync.java
@@ -29,9 +29,6 @@ import net.william278.desertwell.util.UpdateChecker;
 import net.william278.desertwell.util.Version;
 import net.william278.husksync.adapter.DataAdapter;
 import net.william278.husksync.config.ConfigProvider;
-import net.william278.husksync.config.Locales;
-import net.william278.husksync.config.Server;
-import net.william278.husksync.config.Settings;
 import net.william278.husksync.data.Data;
 import net.william278.husksync.data.Identifier;
 import net.william278.husksync.data.Serializer;
@@ -179,31 +176,6 @@ public interface HuskSync extends Task.Supplier, EventDispatcher, ConfigProvider
         }
         log(Level.INFO, "Successfully initialized " + name);
     }
-
-    /**
-     * Returns the plugin {@link Settings}
-     *
-     * @return the {@link Settings}
-     */
-    @NotNull
-    Settings getSettings();
-
-    void setSettings(@NotNull Settings settings);
-
-    @NotNull
-    String getServerName();
-
-    void setServerName(@NotNull Server serverName);
-
-    /**
-     * Returns the plugin {@link Locales}
-     *
-     * @return the {@link Locales}
-     */
-    @NotNull
-    Locales getLocales();
-
-    void setLocales(@NotNull Locales locales);
 
     /**
      * Returns if a dependency is loaded

--- a/common/src/main/java/net/william278/husksync/data/Data.java
+++ b/common/src/main/java/net/william278/husksync/data/Data.java
@@ -19,7 +19,7 @@
 
 package net.william278.husksync.data;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import net.kyori.adventure.key.Key;
 import net.william278.husksync.HuskSync;
@@ -320,7 +320,7 @@ public interface Data {
         record Attribute(
                 @NotNull String name,
                 double baseValue,
-                @NotNull List<Modifier> modifiers
+                @NotNull Set<Modifier> modifiers
         ) {
 
             public double getValue() {
@@ -374,7 +374,7 @@ public interface Data {
 
         default void setMaxHealth(double maxHealth) {
             removeAttribute(MAX_HEALTH_KEY);
-            getAttributes().add(new Attribute(MAX_HEALTH_KEY.asString(), maxHealth, Lists.newArrayList()));
+            getAttributes().add(new Attribute(MAX_HEALTH_KEY.asString(), maxHealth, Sets.newHashSet()));
         }
 
     }

--- a/common/src/main/java/net/william278/husksync/data/Data.java
+++ b/common/src/main/java/net/william278/husksync/data/Data.java
@@ -20,6 +20,7 @@
 package net.william278.husksync.data;
 
 import com.google.gson.annotations.SerializedName;
+import net.kyori.adventure.key.Key;
 import net.william278.husksync.HuskSync;
 import net.william278.husksync.user.OnlineUser;
 import org.jetbrains.annotations.NotNull;
@@ -286,13 +287,64 @@ public interface Data {
 
         void setHealth(double health);
 
-        double getMaxHealth();
+        /**
+         * @deprecated Use {@link Attributes#getMaxHealth()} instead
+         */
+        @Deprecated(forRemoval = true, since = "3.5")
+        default double getMaxHealth() {
+            return getHealth();
+        }
 
-        void setMaxHealth(double maxHealth);
+        /**
+         * @deprecated Use {@link Attributes#setMaxHealth(double)} instead
+         */
+        @Deprecated(forRemoval = true, since = "3.5")
+        default void setMaxHealth(double maxHealth) {
+        }
 
         double getHealthScale();
 
         void setHealthScale(double healthScale);
+    }
+
+    /**
+     * A data container holding player attribute data
+     */
+    interface Attributes extends Data {
+
+        Key MAX_HEALTH_KEY = Key.key("generic.max_health");
+
+        List<Attribute> getAttributes();
+
+        record Attribute(
+                @NotNull String name,
+                double baseValue,
+                @NotNull List<Modifier> modifiers
+        ) {
+        }
+
+        record Modifier(
+                @NotNull UUID uuid,
+                @NotNull String name,
+                double amount,
+                @SerializedName("operation") int operationType,
+                @SerializedName("equipment_slot") int equipmentSlot
+        ) {
+
+            @Override
+            public boolean equals(Object obj) {
+                return obj instanceof Modifier modifier && modifier.uuid.equals(uuid);
+            }
+        }
+
+        default double getMaxHealth() {
+            return 20.0; // TODO - WIP
+        }
+
+        default void setMaxHealth(double maxHealth) {
+            // TODO - WIP
+        }
+
     }
 
     /**

--- a/common/src/main/java/net/william278/husksync/data/DataHolder.java
+++ b/common/src/main/java/net/william278/husksync/data/DataHolder.java
@@ -111,6 +111,15 @@ public interface DataHolder {
     }
 
     @NotNull
+    default Optional<Data.Attributes> getAttributes() {
+        return Optional.ofNullable((Data.Attributes) getData().get(Identifier.ATTRIBUTES));
+    }
+
+    default void setAttributes(@NotNull Data.Attributes attributes) {
+        getData().put(Identifier.ATTRIBUTES, attributes);
+    }
+
+    @NotNull
     default Optional<Data.Experience> getExperience() {
         return Optional.ofNullable((Data.Experience) getData().get(Identifier.EXPERIENCE));
     }

--- a/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
+++ b/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
@@ -660,6 +660,21 @@ public class DataSnapshot {
         }
 
         /**
+         * Set the attributes of the snapshot
+         * <p>
+         * Equivalent to {@code data(Identifier.ATTRIBUTES, attributes)}
+         * </p>
+         *
+         * @param attributes The user's attributes
+         * @return The builder
+         * @since 3.5
+         */
+        @NotNull
+        public Builder attributes(@NotNull Data.Attributes attributes) {
+            return data(Identifier.ATTRIBUTES, attributes);
+        }
+
+        /**
          * Set the experience of the snapshot
          * <p>
          * Equivalent to {@code data(Identifier.EXPERIENCE, experience)}

--- a/common/src/main/java/net/william278/husksync/data/Identifier.java
+++ b/common/src/main/java/net/william278/husksync/data/Identifier.java
@@ -41,6 +41,7 @@ public class Identifier {
     public static Identifier STATISTICS = huskSync("statistics", true);
     public static Identifier HEALTH = huskSync("health", true);
     public static Identifier HUNGER = huskSync("hunger", true);
+    public static Identifier ATTRIBUTES = huskSync("attributes", true);
     public static Identifier EXPERIENCE = huskSync("experience", true);
     public static Identifier GAME_MODE = huskSync("game_mode", true);
     public static Identifier FLIGHT_STATUS = huskSync("flight_status", true);
@@ -114,8 +115,8 @@ public class Identifier {
     @SuppressWarnings("unchecked")
     public static Map<String, Boolean> getConfigMap() {
         return Map.ofEntries(Stream.of(
-                        INVENTORY, ENDER_CHEST, POTION_EFFECTS, ADVANCEMENTS, LOCATION,
-                        STATISTICS, HEALTH, HUNGER, EXPERIENCE, GAME_MODE, FLIGHT_STATUS, PERSISTENT_DATA
+                        INVENTORY, ENDER_CHEST, POTION_EFFECTS, ADVANCEMENTS, LOCATION, STATISTICS,
+                        HEALTH, HUNGER, ATTRIBUTES, EXPERIENCE, GAME_MODE, FLIGHT_STATUS, PERSISTENT_DATA
                 )
                 .map(Identifier::getConfigEntry)
                 .toArray(Map.Entry[]::new));

--- a/common/src/main/java/net/william278/husksync/hook/PlanHook.java
+++ b/common/src/main/java/net/william278/husksync/hook/PlanHook.java
@@ -184,7 +184,7 @@ public class PlanHook {
         public String getHealth(@NotNull UUID uuid) {
             return getLatestSnapshot(uuid)
                     .flatMap(DataHolder::getHealth)
-                    .map(health -> String.format("%s / %s", health.getHealth(), health.getMaxHealth()))
+                    .map(health -> String.format("%s", health.getHealth()))
                     .orElse(UNKNOWN_STRING);
         }
 

--- a/common/src/main/java/net/william278/husksync/util/DataSnapshotOverview.java
+++ b/common/src/main/java/net/william278/husksync/util/DataSnapshotOverview.java
@@ -77,16 +77,17 @@ public class DataSnapshotOverview {
 
         // User status data, if present in the snapshot
         final Optional<Data.Health> health = snapshot.getHealth();
+        final Optional<Data.Attributes> attributes = snapshot.getAttributes();
         final Optional<Data.Hunger> food = snapshot.getHunger();
-        final Optional<Data.Experience> experience = snapshot.getExperience();
-        final Optional<Data.GameMode> gameMode = snapshot.getGameMode();
-        if (health.isPresent() && food.isPresent() && experience.isPresent() && gameMode.isPresent()) {
+        final Optional<Data.Experience> exp = snapshot.getExperience();
+        final Optional<Data.GameMode> mode = snapshot.getGameMode();
+        if (health.isPresent() && attributes.isPresent() && food.isPresent() && exp.isPresent() && mode.isPresent()) {
             locales.getLocale("data_manager_status",
                             Integer.toString((int) health.get().getHealth()),
-                            Integer.toString((int) health.get().getMaxHealth()),
+                            Integer.toString((int) attributes.get().getMaxHealth()),
                             Integer.toString(food.get().getFoodLevel()),
-                            Integer.toString(experience.get().getExpLevel()),
-                            gameMode.get().getGameMode().toLowerCase(Locale.ENGLISH))
+                            Integer.toString(exp.get().getExpLevel()),
+                            mode.get().getGameMode().toLowerCase(Locale.ENGLISH))
                     .ifPresent(user::sendMessage);
         }
 

--- a/docs/Sync-Features.md
+++ b/docs/Sync-Features.md
@@ -5,23 +5,24 @@ You can customise how much data HuskSync saves about a player by [turning each s
 ## Feature table
 ✅&mdash;Supported&nbsp; ❌&mdash;Unsupported&nbsp; ⚠️&mdash;Experimental
 
-| Name                      | Description                                                 | Availability |
-|---------------------------|-------------------------------------------------------------|:------------:|
-| Inventories               | Items in player inventories & selected hotbar slot          |      ✅       |
-| Ender chests              | Items in ender chests&midast;                               |      ✅       |
-| Health                    | Player health points                                        |      ✅       |
-| Max health                | Player max health points and health scale                   |      ✅       |
-| Hunger                    | Player hunger, saturation & exhaustion                      |      ✅       |
-| Experience                | Player level, experience points & score                     |      ✅       |
-| Potion effects            | Active status effects on players                            |      ✅       |
-| Advancements              | Player advancements, recipes & progress                     |      ✅       |
-| Game modes                | Player's current game mode                                  |      ✅       |
-| Statistics                | Player's in-game stats (ESC -> Statistics)                  |      ✅       |
-| Location                  | Player's current coordinate positon and world&dagger;       |      ✅       |
-| Persistent Data Container | Custom plugin persistent data key map                       |      ✅️      |
-| Locked maps               | Maps/treasure maps locked in a cartography table            |      ⚠️      |
-| Unlocked maps             | Regular, unlocked maps/treasure maps ([why?](#map-syncing)) |      ❌       |
-| Economy balances          | Vault economy balance. ([why?](#economy-syncing))           |      ❌       |
+| Name                      | Description                                                                                 | Availability |
+|---------------------------|---------------------------------------------------------------------------------------------|:------------:|
+| Inventories               | Items in player inventories & selected hotbar slot                                          |      ✅       |
+| Ender chests              | Items in ender chests&midast;                                                               |      ✅       |
+| Health                    | Player health points and scale                                                              |      ✅       |
+| Hunger                    | Player hunger, saturation & exhaustion                                                      |      ✅       |
+| Attributes                | Player max health, movement speed, reach, etc. ([wiki](https://minecraft.wiki/w/Attribute)) |      ✅       |
+| Experience                | Player level, experience points & score                                                     |      ✅       |
+| Potion effects            | Active status effects on players                                                            |      ✅       |
+| Advancements              | Player advancements, recipes & progress                                                     |      ✅       |
+| Game modes                | Player's current game mode                                                                  |      ✅       |
+| Flight status             | If the player is currently flying / can fly                                                 |      ✅       |
+| Statistics                | Player's in-game stats (ESC -> Statistics)                                                  |      ✅       |
+| Location                  | Player's current coordinate position and world&dagger;                                      |      ✅       |
+| Persistent Data Container | Custom plugin persistent data key map                                                       |      ✅️      |
+| Locked maps               | Maps/treasure maps locked in a cartography table                                            |      ✅       |
+| Unlocked maps             | Regular, unlocked maps/treasure maps ([why?](#map-syncing))                                 |      ❌       |
+| Economy balances          | Vault economy balance. ([why?](#economy-syncing))                                           |      ❌       |
 
 What about modded items? Or custom item plugins such as MMOItems or SlimeFun? These items are **not compatible**&mdash;check the [[FAQs]] for more information.
 


### PR DESCRIPTION
Closes #219. Closes #249.

Adds support for syncing attributes applied to players, including modifiers and instances and fixes issues related to health and max health syncing.

The following data values which can be attributed to the player will now be properly synced:
* Flight speed
* Movement speed
* Luck
* Knockback resistance
* Mob pathfind follow range
* Knockback
* Attack speed
* Max absorption (1.20.2+)
This means that plugins/commands modifying player attributes directly will now be correctly synced cross-server. This system now also better takes into account modifiers from equipment and potion effects.

This also futureproofs support for syncing these newly customizable values coming in 1.20.5/1.21:
* Block breaking speed
* Entity/block mining range ("reach")
* Step height
* Jump strength
* Distance you can fall without taking fall damage
* Fall damage calculation multiplier
* Gravitational pull