### PR TITLE
fix: add client `SETTING` packet to allow list, fix #286

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedPacketListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitLockedPacketListener.java
@@ -49,7 +49,8 @@ public class BukkitLockedPacketListener extends BukkitLockedEventListener implem
                 Client.KEEP_ALIVE, Client.PONG, Client.CUSTOM_PAYLOAD, // Connection packets
                 Client.CHAT_COMMAND, Client.CLIENT_COMMAND, Client.CHAT, Client.CHAT_SESSION_UPDATE, // Chat / command packets
                 Client.POSITION, Client.POSITION_LOOK, Client.LOOK, // Movement packets
-                Client.HELD_ITEM_SLOT, Client.ARM_ANIMATION, Client.TELEPORT_ACCEPT // Animation packets
+                Client.HELD_ITEM_SLOT, Client.ARM_ANIMATION, Client.TELEPORT_ACCEPT, // Animation packets
+                Client.SETTINGS // Video setting packets
         );
 
         private final BukkitLockedPacketListener listener;


### PR DESCRIPTION
Video setting packets get cancelled when using ProtocolLib to cancel player actions, which caused player skins and chunks load incompletely on player join. This is discussed in #286.