### PR TITLE
Grgit null reference fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,9 +99,11 @@ allprojects {
     }
 
     processResources {
+        def tokenMap = rootProject.ext.properties
+        tokenMap.merge("grgit",'',(s, s2) -> s)
         filesMatching(['**/*.json', '**/*.yml']) {
             filter ReplaceTokens as Class, beginToken: '${', endToken: '}',
-                    tokens: rootProject.ext.properties
+                    tokens: tokenMap
         }
     }
 }


### PR DESCRIPTION
Issue Summary:
when sources are downloaded (not through git) the build fails because of a null reference.
Fix:
replace null reference with empty string.
see [https://github.com/WiIIiam278/HuskSync/issues/345](url) for more information.