### PR TITLE
Update Item-NBT-API to 2.13.2

### DIFF
--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     implementation 'net.kyori:adventure-platform-bukkit:4.3.3'
     implementation 'dev.triumphteam:triumph-gui:3.1.10'
     implementation 'space.arim.morepaperlib:morepaperlib:0.4.4'
-    implementation 'de.tr7zw:item-nbt-api:2.13.1'
+    implementation 'de.tr7zw:item-nbt-api:2.13.2'
 
     compileOnly 'org.spigotmc:spigot-api:1.17.1-R0.1-SNAPSHOT'
     compileOnly 'com.github.retrooper.packetevents:spigot:2.3.0'


### PR DESCRIPTION
This makes the plugin compatible with Paper 1.21.1