### PR TITLE
Add createTables Config Option to Disable Automatic DDL Operations

### DIFF
--- a/common/src/main/java/net/william278/husksync/config/Settings.java
+++ b/common/src/main/java/net/william278/husksync/config/Settings.java
@@ -95,6 +95,9 @@ public class Settings {
         @Comment("Specify credentials here for your MYSQL, MARIADB, POSTGRES OR MONGO database")
         private DatabaseCredentials credentials = new DatabaseCredentials();
 
+        @Comment("Whether to run the creation SQL on the database when the server starts. Don't modify this unless you know what you're doing!")
+        private boolean createTables = true;
+
         @Getter
         @Configuration
         @NoArgsConstructor(access = AccessLevel.PRIVATE)

--- a/common/src/main/java/net/william278/husksync/config/Settings.java
+++ b/common/src/main/java/net/william278/husksync/config/Settings.java
@@ -95,9 +95,6 @@ public class Settings {
         @Comment("Specify credentials here for your MYSQL, MARIADB, POSTGRES OR MONGO database")
         private DatabaseCredentials credentials = new DatabaseCredentials();
 
-        @Comment("Whether to run the creation SQL on the database when the server starts. Don't modify this unless you know what you're doing!")
-        private boolean createTables = true;
-
         @Getter
         @Configuration
         @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -143,6 +140,9 @@ public class Settings {
         @Comment("Names of tables to use on your database. Don't modify this unless you know what you're doing!")
         @Getter(AccessLevel.NONE)
         private Map<String, String> tableNames = Database.TableName.getDefaults();
+
+        @Comment("Whether to run the creation SQL on the database when the server starts. Don't modify this unless you know what you're doing!")
+        private boolean createTables = true;
 
         @NotNull
         public String getTableName(@NotNull Database.TableName tableName) {

--- a/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
@@ -64,6 +64,10 @@ public class MongoDbDatabase extends Database {
             ConnectionString URI = createConnectionURI(credentials);
             mongoConnectionHandler = new MongoConnectionHandler(URI, credentials.getDatabase());
             mongoCollectionHelper = new MongoCollectionHelper(mongoConnectionHandler);
+
+            // Check config for if tables should be created
+            if (!plugin.getSettings().getDatabase().isCreateTables()) return;
+
             if (mongoCollectionHelper.getCollection(usersTable) == null) {
                 mongoCollectionHelper.createCollection(usersTable);
             }

--- a/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
@@ -115,6 +115,9 @@ public class MySqlDatabase extends Database {
         );
         dataSource.setDataSourceProperties(properties);
 
+        // Check config for if tables should be created
+        if (!plugin.getSettings().getDatabase().isCreateTables()) return;
+
         // Prepare database schema; make tables if they don't exist
         try (Connection connection = dataSource.getConnection()) {
             final String[] databaseSchema = getSchemaStatements(String.format("database/%s_schema.sql", flavor));

--- a/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
@@ -108,6 +108,9 @@ public class PostgresDatabase extends Database {
         );
         dataSource.setDataSourceProperties(properties);
 
+        // Check config for if tables should be created
+        if (!plugin.getSettings().getDatabase().isCreateTables()) return;
+
         // Prepare database schema; make tables if they don't exist
         try (Connection connection = dataSource.getConnection()) {
             final String[] databaseSchema = getSchemaStatements(String.format("database/%s_schema.sql", flavor));


### PR DESCRIPTION
### Summary:
This PR introduces a new configuration option called `createTables` to the database adapters. This option allows users to toggle whether the database adapters should attempt to run their table creation (DDL) schema files. 

### Context & Motivation:
In certain production environments, database servers are configured to disable Data Definition Language (DDL) modifications, such as table creation, to maintain stability and security. In such cases, automatically running the table creation schema may result in errors or unintended behavior.

To address this, the `createTables` option provides more flexibility by allowing users to control whether schema creation is attempted during database initialization.

### Changes:
- **New Config Option:**
  - Added `createTables` to the configuration file.
  - Type: `Boolean`
  - Default: `true` (maintains current behavior).
  - When set to `false`, the database adapters will skip running their schema creation scripts, preventing any DDL operations.

- **Database Adapter Updates:**
  - Modified the logic in each relevant database adapter to check the `createTables` flag before executing any schema creation scripts.

### Usage:
- To disable table creation in a production environment:
  ```yml
   ... other configs ...

  # Whether to run the creation SQL on the database when the server starts. Don't modify this unless you know what you're doing!
  create_tables: false

   ... other configs ...
  ```
  This ensures that the application will not attempt to modify the database schema, preventing any conflicts with database policies that disable DDL operations.

### Testing:
- Manual tests were performed on environments where DDL operations are disabled to confirm the configuration works as expected.

### Impact:
- **Backward Compatibility**: The default value of `createTables` is set to `true`, ensuring that existing functionality remains unchanged for users who do not modify their configuration.
- **Production Safety**: Provides a safe and configurable way to disable DDL operations in production environments, reducing the risk of errors caused by unauthorized schema modifications.
- **Potential Issues**: If `createTables` is set to `false` and the required database schema is not already in place, this can lead to runtime errors or missing tables. This setting should only be used by users who are certain that the schema has already been applied to the database. It is recommended for advanced users familiar with their database environment and schema management processes.