### PR TITLE
Fix Postgres snapshot updating

### DIFF
--- a/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
@@ -416,8 +416,8 @@ public class PostgresDatabase extends Database {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     UPDATE %user_data_table%
                     SET save_cause=?,pinned=?,data=?
-                    WHERE player_uuid=? AND version_uuid=?
-                    LIMIT 1;"""))) {
+                    WHERE player_uuid=? AND version_uuid=?;
+                    """))) {
                 statement.setString(1, data.getSaveCause().name());
                 statement.setBoolean(2, data.isPinned());
                 statement.setBytes(3, data.asBytes(plugin));


### PR DESCRIPTION
As per [PostgreSQL documentation](https://www.postgresql.org/docs/current/sql-update.html), "... there is no LIMIT clause for UPDATE ...". This error prevented pinning/unpinning snapshots when using Postgres.