### PR TITLE
Rework locked maps syncing

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -133,7 +133,7 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
     @EventHandler(ignoreCancelled = true)
     public void onMapInitialize(@NotNull MapInitializeEvent event) {
         if (plugin.getSettings().getSynchronization().isPersistLockedMaps() && event.getMap().isLocked()) {
-            getPlugin().runAsync(() -> ((BukkitHuskSync) plugin).renderMapFromFile(event.getMap()));
+            getPlugin().runAsync(() -> ((BukkitHuskSync) plugin).renderMapFromDb(event.getMap()));
         }
     }
 

--- a/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
+++ b/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
@@ -31,8 +31,11 @@ import net.william278.mapdataapi.MapData;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.block.Container;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.BlockStateMeta;
+import org.bukkit.inventory.meta.BundleMeta;
 import org.bukkit.inventory.meta.MapMeta;
 import org.bukkit.map.*;
 import org.jetbrains.annotations.ApiStatus;
@@ -43,6 +46,7 @@ import java.awt.*;
 import java.io.File;
 import java.util.List;
 import java.util.*;
+import java.util.function.Function;
 import java.util.logging.Level;
 
 public interface BukkitMapPersister {

--- a/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
+++ b/bukkit/src/main/java/net/william278/husksync/util/BukkitMapPersister.java
@@ -200,9 +200,9 @@ public interface BukkitMapPersister {
             final MapView view = generateRenderedMap(canvasData);
             meta.setMapView(view);
             map.setItemMeta(meta);
-            getPlugin().getDatabase().connectMapIds(originWorldId, originalMapId, currentWorldId, view.getId());
+            getPlugin().getDatabase().bindMapIds(originWorldId, originalMapId, currentWorldId, view.getId());
 
-            getPlugin().debug(String.format("Connected map to view (#%s) in world %s", view.getId(), currentWorldId));
+            getPlugin().debug(String.format("Bound map to view (#%s) in world %s", view.getId(), currentWorldId));
         });
         return map;
     }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     api 'commons-io:commons-io:2.18.0'
     api 'org.apache.commons:commons-text:1.12.0'
     api 'net.william278:minedown:1.8.2'
+    api 'net.william278:mapdataapi:2.0'
     api 'org.json:json:20240303'
     api 'com.google.code.gson:gson:2.11.0'
     api 'com.fatboyindustrial.gson-javatime-serialisers:gson-javatime-serialisers:1.1.2'

--- a/common/src/main/java/net/william278/husksync/command/HuskSyncCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/HuskSyncCommand.java
@@ -69,7 +69,8 @@ public class HuskSyncCommand extends PluginCommand {
                         AboutMenu.Credit.of("HookWoods").description("Code"),
                         AboutMenu.Credit.of("Preva1l").description("Code"),
                         AboutMenu.Credit.of("hanbings").description("Code (Fabric porting)"),
-                        AboutMenu.Credit.of("Stampede2011").description("Code (Fabric mixins)"))
+                        AboutMenu.Credit.of("Stampede2011").description("Code (Fabric mixins)"),
+                        AboutMenu.Credit.of("VinerDream").description("Code"))
                 .credits("Translators",
                         AboutMenu.Credit.of("Namiu").description("Japanese (ja-jp)"),
                         AboutMenu.Credit.of("anchelthe").description("Spanish (es-es)"),

--- a/common/src/main/java/net/william278/husksync/data/AdaptableMapData.java
+++ b/common/src/main/java/net/william278/husksync/data/AdaptableMapData.java
@@ -1,0 +1,25 @@
+package net.william278.husksync.data;
+
+import com.google.gson.annotations.SerializedName;
+import org.jetbrains.annotations.NotNull;
+import net.william278.husksync.adapter.Adaptable;
+import net.william278.mapdataapi.MapData;
+
+import java.io.IOException;
+
+public class AdaptableMapData implements Adaptable {
+    @SerializedName("data")
+    private final byte[] data;
+
+    public AdaptableMapData(byte @NotNull [] data) {
+        this.data = data;
+    }
+
+    public AdaptableMapData(MapData data) {
+        this(data.toBytes());
+    }
+
+    public MapData getData(int dataVersion) throws IOException {
+        return MapData.fromByteArray(dataVersion, data);
+    }
+}

--- a/common/src/main/java/net/william278/husksync/database/Database.java
+++ b/common/src/main/java/net/william278/husksync/database/Database.java
@@ -57,8 +57,8 @@ public abstract class Database {
     @SuppressWarnings("SameParameterValue")
     @NotNull
     protected final String[] getSchemaStatements(@NotNull String schemaFileName) throws IOException {
-        return formatStatementTables(new String(Objects.requireNonNull(plugin.getResource(schemaFileName))
-                .readAllBytes(), StandardCharsets.UTF_8)).split(";");
+        return Arrays.stream(formatStatementTables(new String(Objects.requireNonNull(plugin.getResource(schemaFileName))
+                .readAllBytes(), StandardCharsets.UTF_8)).split(";")).filter(s -> !s.isBlank()).toArray(String[]::new);
     }
 
     /**

--- a/common/src/main/java/net/william278/husksync/database/Database.java
+++ b/common/src/main/java/net/william278/husksync/database/Database.java
@@ -252,44 +252,44 @@ public abstract class Database {
     /**
      * Write map data to a database
      *
-     * @param worldId ID of the world the map originates from
-     * @param mapId   Original map ID
-     * @param data    Map data
+     * @param serverName Name of the server the map originates from
+     * @param mapId      Original map ID
+     * @param data       Map data
      */
     @Blocking
-    public abstract void writeMapData(@NotNull UUID worldId, int mapId, byte @NotNull [] data);
+    public abstract void writeMapData(@NotNull String serverName, int mapId, byte @NotNull [] data);
 
     /**
      * Read map data from a database
      *
-     * @param worldId ID of the world the map originates from
-     * @param mapId   Original map ID
-     * @return Map.Entry (key: map data, value: is from current world)
+     * @param serverName Name of the server the map originates from
+     * @param mapId      Original map ID
+     * @return           Map.Entry (key: map data, value: is from current world)
      */
     @Blocking
-    public abstract @Nullable Map.Entry<byte[], Boolean> readMapData(@NotNull UUID worldId, int mapId);
+    public abstract @Nullable Map.Entry<byte[], Boolean> readMapData(@NotNull String serverName, int mapId);
 
     /**
-     * Bind map IDs across different worlds
+     * Bind map IDs across different servers
      *
-     * @param fromWorldId ID of the world the map originates from
-     * @param fromMapId   Original map ID
-     * @param toWorldId   ID of the new world
-     * @param toMapId     New map ID
+     * @param fromServerName Name of the server the map originates from
+     * @param fromMapId      Original map ID
+     * @param toServerName   Name of the new server
+     * @param toMapId        New map ID
      */
     @Blocking
-    public abstract void bindMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId);
+    public abstract void bindMapIds(@NotNull String fromServerName, int fromMapId, @NotNull String toServerName, int toMapId);
 
     /**
-     * Get map ID for the new world
+     * Get map ID for the new server
      *
-     * @param fromWorldId ID of the world the map originates from
-     * @param fromMapId   Original map ID
-     * @param toWorldId   ID of the new world
-     * @return            New map ID or -1 if not found
+     * @param fromServerName Name of the server the map originates from
+     * @param fromMapId      Original map ID
+     * @param toServerName   Name of the new server
+     * @return               New map ID or -1 if not found
      */
     @Blocking
-    public abstract int getNewMapId(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId);
+    public abstract int getNewMapId(@NotNull String fromServerName, int fromMapId, @NotNull String toServerName);
 
     /**
      * Wipes <b>all</b> {@link User} entries from the database.

--- a/common/src/main/java/net/william278/husksync/database/Database.java
+++ b/common/src/main/java/net/william278/husksync/database/Database.java
@@ -270,7 +270,7 @@ public abstract class Database {
     public abstract @Nullable Map.Entry<byte[], Boolean> readMapData(@NotNull UUID worldId, int mapId);
 
     /**
-     * Connect map IDs across different worlds
+     * Bind map IDs across different worlds
      *
      * @param fromWorldId ID of the world the map originates from
      * @param fromMapId   Original map ID
@@ -278,7 +278,7 @@ public abstract class Database {
      * @param toMapId     New map ID
      */
     @Blocking
-    public abstract void connectMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId);
+    public abstract void bindMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId);
 
     /**
      * Get map ID for the new world

--- a/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
@@ -35,13 +35,11 @@ import org.bson.conversions.Bson;
 import org.bson.types.Binary;
 import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Optional;
-import java.util.TimeZone;
-import java.util.UUID;
+import java.util.*;
 import java.util.logging.Level;
 
 public class MongoDbDatabase extends Database {
@@ -50,11 +48,15 @@ public class MongoDbDatabase extends Database {
 
     private final String usersTable;
     private final String userDataTable;
+    private final String mapDataTable;
+    private final String mapIdsTable;
 
     public MongoDbDatabase(@NotNull HuskSync plugin) {
         super(plugin);
         this.usersTable = plugin.getSettings().getDatabase().getTableName(TableName.USERS);
         this.userDataTable = plugin.getSettings().getDatabase().getTableName(TableName.USER_DATA);
+        this.mapDataTable = plugin.getSettings().getDatabase().getTableName(TableName.MAP_DATA);
+        this.mapIdsTable = plugin.getSettings().getDatabase().getTableName(TableName.MAP_IDS);
     }
 
     @Override
@@ -73,6 +75,12 @@ public class MongoDbDatabase extends Database {
             }
             if (mongoCollectionHelper.getCollection(userDataTable) == null) {
                 mongoCollectionHelper.createCollection(userDataTable);
+            }
+            if (mongoCollectionHelper.getCollection(mapDataTable) == null) {
+                mongoCollectionHelper.createCollection(mapDataTable);
+            }
+            if (mongoCollectionHelper.getCollection(mapIdsTable) == null) {
+                mongoCollectionHelper.createCollection(mapIdsTable);
             }
         } catch (Exception e) {
             throw new IllegalStateException("Failed to establish a connection to the MongoDB database. " +
@@ -342,6 +350,79 @@ public class MongoDbDatabase extends Database {
             mongoCollectionHelper.updateDocument(userDataTable, doc, updates);
         } catch (MongoException e) {
             plugin.log(Level.SEVERE, "Failed to update snapshot in the database", e);
+        }
+    }
+
+    @Blocking
+    @Override
+    public void writeMapData(@NotNull UUID worldId, int mapId, byte @NotNull [] data) {
+        try {
+            Document doc = new Document("world_uuid", worldId)
+                    .append("map_id", mapId)
+                    .append("data", new Binary(data));
+            mongoCollectionHelper.insertDocument(mapDataTable, doc);
+        } catch (MongoException e) {
+            plugin.log(Level.SEVERE, "Failed to write map data to the database", e);
+        }
+    }
+
+    @Blocking
+    @Override
+    public @Nullable Map.Entry<byte[], Boolean> readMapData(@NotNull UUID worldId, int mapId) {
+        try {
+            Document filter = new Document("world_uuid", worldId).append("map_id", mapId);
+            FindIterable<Document> iterable = mongoCollectionHelper.getCollection(mapDataTable).find(filter);
+            Document doc = iterable.first();
+            if (doc != null) {
+                final Binary bin = doc.get("data", Binary.class);
+                return Map.entry(bin.getData(), true);
+            } else {
+                filter = new Document("to_world_uuid", worldId).append("to_id", mapId);
+                iterable = mongoCollectionHelper.getCollection(mapIdsTable).find(filter);
+                doc = iterable.first();
+                if (doc != null) {
+                    var result = readMapData(doc.get("from_world_uuid", UUID.class), doc.getInteger("from_id"));
+                    if (result != null) {
+                        return Map.entry(result.getKey(), false);
+                    }
+                }
+            }
+            return null;
+        } catch (MongoException e) {
+            plugin.log(Level.SEVERE, "Failed to get map data from the database", e);
+            return null;
+        }
+    }
+
+    @Blocking
+    @Override
+    public void connectMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId) {
+        try {
+            Document doc = new Document("from_world_uuid", fromWorldId)
+                    .append("from_id", fromMapId)
+                    .append("to_world_uuid", toWorldId)
+                    .append("to_id", toMapId);
+            mongoCollectionHelper.insertDocument(mapIdsTable, doc);
+        } catch (MongoException e) {
+            plugin.log(Level.SEVERE, "Failed to connect map IDs in the database", e);
+        }
+    }
+
+    @Blocking
+    @Override
+    public int getNewMapId(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId) {
+        try {
+            Document filter = new Document("from_world_uuid", fromWorldId).append("from_id", fromMapId)
+                    .append("to_world_uuid", toWorldId);
+            FindIterable<Document> iterable = mongoCollectionHelper.getCollection(mapIdsTable).find(filter);
+            Document doc = iterable.first();
+            if (doc != null) {
+                return doc.getInteger("to_id");
+            }
+            return -1;
+        } catch (MongoException e) {
+            plugin.log(Level.SEVERE, "Failed to get new map id from the database", e);
+            return -1;
         }
     }
 

--- a/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
@@ -412,6 +412,7 @@ public class MongoDbDatabase extends Database {
     @Blocking
     @Override
     public void bindMapIds(@NotNull String fromServerName, int fromMapId, @NotNull String toServerName, int toMapId) {
+        plugin.getRedisManager().bindMapIds(fromServerName, fromMapId, toServerName, toMapId);
         try {
             Document doc = new Document("from_server_name", fromServerName)
                     .append("from_id", fromMapId)

--- a/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
@@ -396,7 +396,7 @@ public class MongoDbDatabase extends Database {
 
     @Blocking
     @Override
-    public void connectMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId) {
+    public void bindMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId) {
         try {
             Document doc = new Document("from_world_uuid", fromWorldId)
                     .append("from_id", fromMapId)

--- a/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
@@ -27,6 +27,7 @@ import net.william278.husksync.data.DataSnapshot;
 import net.william278.husksync.user.User;
 import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -431,6 +432,107 @@ public class MySqlDatabase extends Database {
         } catch (SQLException e) {
             plugin.log(Level.SEVERE, "Failed to pin user data in the database", e);
         }
+    }
+
+    @Blocking
+    @Override
+    public void writeMapData(@NotNull UUID worldId, int mapId, byte @NotNull [] data) {
+        try (Connection connection = getConnection()) {
+            try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
+                    INSERT INTO `%map_data_table%`
+                    (`world_uuid`,`map_id`,`data`)
+                    VALUES (?,?,?);"""))) {
+                statement.setString(1, worldId.toString());
+                statement.setInt(2, mapId);
+                statement.setBlob(3, new ByteArrayInputStream(data));
+                statement.executeUpdate();
+            }
+        } catch (SQLException | DataAdapter.AdaptionException e) {
+            plugin.log(Level.SEVERE, "Failed to write map data to the database", e);
+        }
+    }
+
+    @Blocking
+    @Override
+    public @Nullable Map.Entry<byte[], Boolean> readMapData(@NotNull UUID worldId, int mapId) {
+        try (Connection connection = getConnection()) {
+            try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
+                    SELECT `data`
+                    FROM `%map_data_table%`
+                    WHERE `world_uuid`=? AND `map_id`=?
+                    LIMIT 1;"""))) {
+                statement.setString(1, worldId.toString());
+                statement.setInt(2, mapId);
+                final ResultSet resultSet = statement.executeQuery();
+                if (resultSet.next()) {
+                    final Blob blob = resultSet.getBlob("data");
+                    final byte[] dataByteArray = blob.getBytes(1, (int) blob.length());
+                    blob.free();
+                    return Map.entry(dataByteArray, true);
+                } else {
+                    PreparedStatement statement2 = connection.prepareStatement(formatStatementTables("""
+                        SELECT `from_world_uuid`, `from_id`
+                        FROM `%map_ids_table%`
+                        WHERE `to_world_uuid`=? AND `to_id`=?
+                        LIMIT 1;
+                    """));
+                    statement2.setString(1, worldId.toString());
+                    statement2.setInt(2, mapId);
+                    final ResultSet resultSet2 = statement2.executeQuery();
+                    if (resultSet2.next()) {
+                        var result = readMapData(UUID.fromString(resultSet2.getString("from_world_uuid")), resultSet2.getInt("from_id"));
+                        if (result != null) {
+                            return Map.entry(result.getKey(), false);
+                        }
+                    }
+                }
+            }
+        } catch (SQLException | DataAdapter.AdaptionException e) {
+            plugin.log(Level.SEVERE, "Failed to get map data from the database", e);
+        }
+        return null;
+    }
+
+    @Blocking
+    @Override
+    public void connectMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId) {
+        try (Connection connection = getConnection()) {
+            try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
+                    INSERT INTO `%map_ids_table%`
+                    (`from_world_uuid`,`from_id`,`to_world_uuid`,`to_id`)
+                    VALUES (?,?,?,?);"""))) {
+                statement.setString(1, fromWorldId.toString());
+                statement.setInt(2, fromMapId);
+                statement.setString(3, toWorldId.toString());
+                statement.setInt(4, toMapId);
+                statement.executeUpdate();
+            }
+        } catch (SQLException | DataAdapter.AdaptionException e) {
+            plugin.log(Level.SEVERE, "Failed to connect map IDs in the database", e);
+        }
+    }
+
+    @Blocking
+    @Override
+    public int getNewMapId(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId) {
+        try (Connection connection = getConnection()) {
+            try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
+                    SELECT `to_id`
+                    FROM `%map_ids_table%`
+                    WHERE `from_world_uuid`=? AND `from_id`=? AND `to_world_uuid`=?
+                    LIMIT 1;"""))) {
+                statement.setString(1, fromWorldId.toString());
+                statement.setInt(2, fromMapId);
+                statement.setString(3, toWorldId.toString());
+                final ResultSet resultSet = statement.executeQuery();
+                if (resultSet.next()) {
+                    return resultSet.getInt("to_id");
+                }
+            }
+        } catch (SQLException | DataAdapter.AdaptionException e) {
+            plugin.log(Level.SEVERE, "Failed to get new map id from the database", e);
+        }
+        return -1;
     }
 
     @Override

--- a/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
@@ -517,6 +517,7 @@ public class MySqlDatabase extends Database {
     @Blocking
     @Override
     public void bindMapIds(@NotNull String fromServerName, int fromMapId, @NotNull String toServerName, int toMapId) {
+        plugin.getRedisManager().bindMapIds(fromServerName, fromMapId, toServerName, toMapId);
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     INSERT INTO `%map_ids_table%`

--- a/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
@@ -495,7 +495,7 @@ public class MySqlDatabase extends Database {
 
     @Blocking
     @Override
-    public void connectMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId) {
+    public void bindMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     INSERT INTO `%map_ids_table%`

--- a/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MySqlDatabase.java
@@ -436,13 +436,13 @@ public class MySqlDatabase extends Database {
 
     @Blocking
     @Override
-    public void writeMapData(@NotNull UUID worldId, int mapId, byte @NotNull [] data) {
+    public void writeMapData(@NotNull String serverName, int mapId, byte @NotNull [] data) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     INSERT INTO `%map_data_table%`
-                    (`world_uuid`,`map_id`,`data`)
+                    (`server_name`,`map_id`,`data`)
                     VALUES (?,?,?);"""))) {
-                statement.setString(1, worldId.toString());
+                statement.setString(1, serverName);
                 statement.setInt(2, mapId);
                 statement.setBlob(3, new ByteArrayInputStream(data));
                 statement.executeUpdate();
@@ -454,14 +454,14 @@ public class MySqlDatabase extends Database {
 
     @Blocking
     @Override
-    public @Nullable Map.Entry<byte[], Boolean> readMapData(@NotNull UUID worldId, int mapId) {
+    public @Nullable Map.Entry<byte[], Boolean> readMapData(@NotNull String serverName, int mapId) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     SELECT `data`
                     FROM `%map_data_table%`
-                    WHERE `world_uuid`=? AND `map_id`=?
+                    WHERE `server_name`=? AND `map_id`=?
                     LIMIT 1;"""))) {
-                statement.setString(1, worldId.toString());
+                statement.setString(1, serverName);
                 statement.setInt(2, mapId);
                 final ResultSet resultSet = statement.executeQuery();
                 if (resultSet.next()) {
@@ -470,7 +470,7 @@ public class MySqlDatabase extends Database {
                     blob.free();
                     return Map.entry(dataByteArray, true);
                 } else {
-                    return readMapDataFromAnotherServer(worldId, mapId);
+                    return readMapDataFromAnotherServer(serverName, mapId);
                 }
             }
         } catch (SQLException | DataAdapter.AdaptionException e) {
@@ -479,19 +479,19 @@ public class MySqlDatabase extends Database {
         return null;
     }
 
-    public @Nullable Map.Entry<byte[], Boolean> readMapDataFromAnotherServer(@NotNull UUID worldId, int mapId) {
+    public @Nullable Map.Entry<byte[], Boolean> readMapDataFromAnotherServer(@NotNull String serverName, int mapId) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
-                    SELECT `from_world_uuid`, `from_id`
+                    SELECT `from_server_name`, `from_id`
                     FROM `%map_ids_table%`
-                    WHERE `to_world_uuid`=? AND `to_id`=?
+                    WHERE `to_server_name`=? AND `to_id`=?
                     LIMIT 1;
                     """))) {
-                statement.setString(1, worldId.toString());
+                statement.setString(1, serverName);
                 statement.setInt(2, mapId);
                 final ResultSet resultSet = statement.executeQuery();
                 if (resultSet.next()) {
-                    var result = readMapData(UUID.fromString(resultSet.getString("from_world_uuid")), resultSet.getInt("from_id"));
+                    var result = readMapData(resultSet.getString("from_server_name"), resultSet.getInt("from_id"));
                     if (result != null) {
                         return Map.entry(result.getKey(), false);
                     }
@@ -505,15 +505,15 @@ public class MySqlDatabase extends Database {
 
     @Blocking
     @Override
-    public void bindMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId) {
+    public void bindMapIds(@NotNull String fromServerName, int fromMapId, @NotNull String toServerName, int toMapId) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     INSERT INTO `%map_ids_table%`
-                    (`from_world_uuid`,`from_id`,`to_world_uuid`,`to_id`)
+                    (`from_server_name`,`from_id`,`to_server_name`,`to_id`)
                     VALUES (?,?,?,?);"""))) {
-                statement.setString(1, fromWorldId.toString());
+                statement.setString(1, fromServerName);
                 statement.setInt(2, fromMapId);
-                statement.setString(3, toWorldId.toString());
+                statement.setString(3, toServerName);
                 statement.setInt(4, toMapId);
                 statement.executeUpdate();
             }
@@ -524,16 +524,16 @@ public class MySqlDatabase extends Database {
 
     @Blocking
     @Override
-    public int getNewMapId(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId) {
+    public int getNewMapId(@NotNull String fromServerName, int fromMapId, @NotNull String toServerName) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     SELECT `to_id`
                     FROM `%map_ids_table%`
-                    WHERE `from_world_uuid`=? AND `from_id`=? AND `to_world_uuid`=?
+                    WHERE `from_server_name`=? AND `from_id`=? AND `to_server_name`=?
                     LIMIT 1;"""))) {
-                statement.setString(1, fromWorldId.toString());
+                statement.setString(1, fromServerName);
                 statement.setInt(2, fromMapId);
-                statement.setString(3, toWorldId.toString());
+                statement.setString(3, toServerName);
                 final ResultSet resultSet = statement.executeQuery();
                 if (resultSet.next()) {
                     return resultSet.getInt("to_id");

--- a/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
@@ -511,6 +511,7 @@ public class PostgresDatabase extends Database {
     @Blocking
     @Override
     public void bindMapIds(@NotNull String fromServerName, int fromMapId, @NotNull String toServerName, int toMapId) {
+        plugin.getRedisManager().bindMapIds(fromServerName, fromMapId, toServerName, toMapId);
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     INSERT INTO %map_ids_table%

--- a/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
@@ -489,7 +489,7 @@ public class PostgresDatabase extends Database {
 
     @Blocking
     @Override
-    public void connectMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId) {
+    public void bindMapIds(@NotNull UUID fromWorldId, int fromMapId, @NotNull UUID toWorldId, int toMapId) {
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     INSERT INTO %map_ids_table%

--- a/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
@@ -474,6 +474,14 @@ public class PostgresDatabase extends Database {
     }
 
     public @Nullable Map.Entry<byte[], Boolean> readMapDataFromAnotherServer(@NotNull String serverName, int mapId) {
+        Map.Entry<String, Integer> reverseBound = plugin.getRedisManager().getReversedMapBound(serverName, mapId);
+        if (reverseBound != null) {
+            var result = readMapData(reverseBound.getKey(), reverseBound.getValue());
+            if (result != null) {
+                return Map.entry(result.getKey(), false);
+            }
+            return null;
+        }
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     SELECT from_server_name, from_id
@@ -485,7 +493,10 @@ public class PostgresDatabase extends Database {
                 statement.setInt(2, mapId);
                 final ResultSet resultSet = statement.executeQuery();
                 if (resultSet.next()) {
-                    var result = readMapData(resultSet.getString("from_server_name"), resultSet.getInt("from_id"));
+                    String fromServer = resultSet.getString("from_server_name");
+                    int fromId = resultSet.getInt("from_id");
+                    plugin.getRedisManager().bindMapIds(fromServer, fromId, serverName, mapId);
+                    var result = readMapData(fromServer, fromId);
                     if (result != null) {
                         return Map.entry(result.getKey(), false);
                     }

--- a/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/PostgresDatabase.java
@@ -519,6 +519,8 @@ public class PostgresDatabase extends Database {
     @Blocking
     @Override
     public int getNewMapId(@NotNull String fromServerName, int fromMapId, @NotNull String toServerName) {
+        Optional<Integer> toIdOptional = plugin.getRedisManager().getBoundMapId(fromServerName, fromMapId, toServerName);
+        if (toIdOptional.isPresent()) return toIdOptional.get();
         try (Connection connection = getConnection()) {
             try (PreparedStatement statement = connection.prepareStatement(formatStatementTables("""
                     SELECT to_id
@@ -530,7 +532,9 @@ public class PostgresDatabase extends Database {
                 statement.setString(3, toServerName);
                 final ResultSet resultSet = statement.executeQuery();
                 if (resultSet.next()) {
-                    return resultSet.getInt("to_id");
+                    int toId = resultSet.getInt("to_id");
+                    plugin.getRedisManager().bindMapIds(fromServerName, fromMapId, toServerName, toId);
+                    return toId;
                 }
             }
         } catch (SQLException | DataAdapter.AdaptionException e) {

--- a/common/src/main/java/net/william278/husksync/redis/RedisKeyType.java
+++ b/common/src/main/java/net/william278/husksync/redis/RedisKeyType.java
@@ -29,7 +29,8 @@ public enum RedisKeyType {
     SERVER_SWITCH,
     DATA_CHECKOUT,
     MAP_ID,
-    MAP_ID_REVERSED;
+    MAP_ID_REVERSED,
+    MAP_DATA;
 
     public static final int TTL_1_YEAR = 60 * 60 * 24 * 7 * 52; // 1 year
     public static final int TTL_10_SECONDS = 10; // 10 seconds

--- a/common/src/main/java/net/william278/husksync/redis/RedisKeyType.java
+++ b/common/src/main/java/net/william278/husksync/redis/RedisKeyType.java
@@ -27,7 +27,9 @@ public enum RedisKeyType {
 
     LATEST_SNAPSHOT,
     SERVER_SWITCH,
-    DATA_CHECKOUT;
+    DATA_CHECKOUT,
+    MAP_ID,
+    MAP_ID_REVERSED;
 
     public static final int TTL_1_YEAR = 60 * 60 * 24 * 7 * 52; // 1 year
     public static final int TTL_10_SECONDS = 10; // 10 seconds

--- a/common/src/main/resources/database/mariadb_schema.sql
+++ b/common/src/main/resources/database/mariadb_schema.sql
@@ -30,3 +30,27 @@ CREATE TABLE IF NOT EXISTS `%user_data_table%`
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci;
+
+-- Create the map data table if it does not exist
+CREATE TABLE IF NOT EXISTS `%map_data_table%`
+(
+    `world_uuid` char(36) NOT NULL,
+    `map_id`     int      NOT NULL,
+    `data`       longblob NOT NULL,
+    PRIMARY KEY (`world_uuid`, `map_id`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+-- Create the map ids table if it does not exist
+CREATE TABLE IF NOT EXISTS `%map_ids_table%`
+(
+    `from_world_uuid` char(36) NOT NULL,
+    `from_id`         int      NOT NULL,
+    `to_world_uuid`   char(36) NOT NULL,
+    `to_id`           int      NOT NULL,
+    PRIMARY KEY (`from_world_uuid`, `from_id`, `to_world_uuid`),
+    FOREIGN KEY (`from_world_uuid`, `from_id`) REFERENCES `%map_data_table%` (`world_uuid`, `map_id`) ON DELETE CASCADE
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/common/src/main/resources/database/mariadb_schema.sql
+++ b/common/src/main/resources/database/mariadb_schema.sql
@@ -34,10 +34,10 @@ CREATE TABLE IF NOT EXISTS `%user_data_table%`
 -- Create the map data table if it does not exist
 CREATE TABLE IF NOT EXISTS `%map_data_table%`
 (
-    `world_uuid` char(36) NOT NULL,
-    `map_id`     int      NOT NULL,
-    `data`       longblob NOT NULL,
-    PRIMARY KEY (`world_uuid`, `map_id`)
+    `server_name` varchar(32) NOT NULL,
+    `map_id`      int         NOT NULL,
+    `data`        longblob    NOT NULL,
+    PRIMARY KEY (`server_name`, `map_id`)
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci;
@@ -45,12 +45,12 @@ CREATE TABLE IF NOT EXISTS `%map_data_table%`
 -- Create the map ids table if it does not exist
 CREATE TABLE IF NOT EXISTS `%map_ids_table%`
 (
-    `from_world_uuid` char(36) NOT NULL,
-    `from_id`         int      NOT NULL,
-    `to_world_uuid`   char(36) NOT NULL,
-    `to_id`           int      NOT NULL,
-    PRIMARY KEY (`from_world_uuid`, `from_id`, `to_world_uuid`),
-    FOREIGN KEY (`from_world_uuid`, `from_id`) REFERENCES `%map_data_table%` (`world_uuid`, `map_id`) ON DELETE CASCADE
+    `from_server_name` varchar(32) NOT NULL,
+    `from_id`          int         NOT NULL,
+    `to_server_name`   varchar(32) NOT NULL,
+    `to_id`            int         NOT NULL,
+    PRIMARY KEY (`from_server_name`, `from_id`, `to_server_name`),
+    FOREIGN KEY (`from_server_name`, `from_id`) REFERENCES `%map_data_table%` (`server_name`, `map_id`) ON DELETE CASCADE
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_unicode_ci;

--- a/common/src/main/resources/database/mysql_schema.sql
+++ b/common/src/main/resources/database/mysql_schema.sql
@@ -27,3 +27,25 @@ CREATE TABLE IF NOT EXISTS `%user_data_table%`
     FOREIGN KEY (`player_uuid`) REFERENCES `%users_table%` (`uuid`) ON DELETE CASCADE
 ) CHARACTER SET utf8
   COLLATE utf8_unicode_ci;
+
+# Create the map data table if it does not exist
+CREATE TABLE IF NOT EXISTS `%map_data_table%`
+(
+    `world_uuid` char(36) NOT NULL,
+    `map_id`     int      NOT NULL,
+    `data`       longblob NOT NULL,
+    PRIMARY KEY (`world_uuid`, `map_id`)
+) CHARACTER SET utf8
+  COLLATE utf8_unicode_ci;
+
+# Create the map ids table if it does not exist
+CREATE TABLE IF NOT EXISTS `%map_ids_table%`
+(
+    `from_world_uuid` char(36) NOT NULL,
+    `from_id`         int      NOT NULL,
+    `to_world_uuid`   char(36) NOT NULL,
+    `to_id`           int      NOT NULL,
+    PRIMARY KEY (`from_world_uuid`, `from_id`, `to_world_uuid`),
+    FOREIGN KEY (`from_world_uuid`, `from_id`) REFERENCES `%map_data_table%` (`world_uuid`, `map_id`) ON DELETE CASCADE
+) CHARACTER SET utf8
+  COLLATE utf8_unicode_ci;

--- a/common/src/main/resources/database/mysql_schema.sql
+++ b/common/src/main/resources/database/mysql_schema.sql
@@ -31,21 +31,21 @@ CREATE TABLE IF NOT EXISTS `%user_data_table%`
 # Create the map data table if it does not exist
 CREATE TABLE IF NOT EXISTS `%map_data_table%`
 (
-    `world_uuid` char(36) NOT NULL,
-    `map_id`     int      NOT NULL,
-    `data`       longblob NOT NULL,
-    PRIMARY KEY (`world_uuid`, `map_id`)
+    `server_name` varchar(32) NOT NULL,
+    `map_id`      int         NOT NULL,
+    `data`        longblob    NOT NULL,
+    PRIMARY KEY (`server_name`, `map_id`)
 ) CHARACTER SET utf8
   COLLATE utf8_unicode_ci;
 
 # Create the map ids table if it does not exist
 CREATE TABLE IF NOT EXISTS `%map_ids_table%`
 (
-    `from_world_uuid` char(36) NOT NULL,
-    `from_id`         int      NOT NULL,
-    `to_world_uuid`   char(36) NOT NULL,
-    `to_id`           int      NOT NULL,
-    PRIMARY KEY (`from_world_uuid`, `from_id`, `to_world_uuid`),
-    FOREIGN KEY (`from_world_uuid`, `from_id`) REFERENCES `%map_data_table%` (`world_uuid`, `map_id`) ON DELETE CASCADE
+    `from_server_name` varchar(32) NOT NULL,
+    `from_id`          int         NOT NULL,
+    `to_server_name`   varchar(32) NOT NULL,
+    `to_id`            int         NOT NULL,
+    PRIMARY KEY (`from_server_name`, `from_id`, `to_server_name`),
+    FOREIGN KEY (`from_server_name`, `from_id`) REFERENCES `%map_data_table%` (`server_name`, `map_id`) ON DELETE CASCADE
 ) CHARACTER SET utf8
   COLLATE utf8_unicode_ci;

--- a/common/src/main/resources/database/postgresql_schema.sql
+++ b/common/src/main/resources/database/postgresql_schema.sql
@@ -20,3 +20,23 @@ CREATE TABLE IF NOT EXISTS "%user_data_table%"
     PRIMARY KEY (version_uuid, player_uuid),
     FOREIGN KEY (player_uuid) REFERENCES "%users_table%" (uuid) ON DELETE CASCADE
 );
+
+-- Create the map data table if it does not exist
+CREATE TABLE IF NOT EXISTS "%map_data_table%"
+(
+    world_uuid uuid  NOT NULL,
+    map_id     int   NOT NULL,
+    data       bytea NOT NULL,
+    PRIMARY KEY (world_uuid, map_id)
+);
+
+-- Create the map ids table if it does not exist
+CREATE TABLE IF NOT EXISTS "%map_ids_table%"
+(
+    from_world_uuid uuid NOT NULL,
+    from_id         int  NOT NULL,
+    to_world_uuid   uuid NOT NULL,
+    to_id           int  NOT NULL,
+    PRIMARY KEY (from_world_uuid, from_id, to_world_uuid),
+    FOREIGN KEY (from_world_uuid, from_id) REFERENCES "%map_data_table%" (world_uuid, map_id) ON DELETE CASCADE
+);

--- a/common/src/main/resources/database/postgresql_schema.sql
+++ b/common/src/main/resources/database/postgresql_schema.sql
@@ -24,19 +24,19 @@ CREATE TABLE IF NOT EXISTS "%user_data_table%"
 -- Create the map data table if it does not exist
 CREATE TABLE IF NOT EXISTS "%map_data_table%"
 (
-    world_uuid uuid  NOT NULL,
-    map_id     int   NOT NULL,
-    data       bytea NOT NULL,
-    PRIMARY KEY (world_uuid, map_id)
+    server_name varchar(32)  NOT NULL,
+    map_id      int          NOT NULL,
+    data        bytea        NOT NULL,
+    PRIMARY KEY (server_name, map_id)
 );
 
 -- Create the map ids table if it does not exist
 CREATE TABLE IF NOT EXISTS "%map_ids_table%"
 (
-    from_world_uuid uuid NOT NULL,
-    from_id         int  NOT NULL,
-    to_world_uuid   uuid NOT NULL,
-    to_id           int  NOT NULL,
-    PRIMARY KEY (from_world_uuid, from_id, to_world_uuid),
-    FOREIGN KEY (from_world_uuid, from_id) REFERENCES "%map_data_table%" (world_uuid, map_id) ON DELETE CASCADE
+    from_server_name varchar(32) NOT NULL,
+    from_id          int         NOT NULL,
+    to_server_name   varchar(32) NOT NULL,
+    to_id            int         NOT NULL,
+    PRIMARY KEY (from_server_name, from_id, to_server_name),
+    FOREIGN KEY (from_server_name, from_id) REFERENCES "%map_data_table%" (server_name, map_id) ON DELETE CASCADE
 );


### PR DESCRIPTION
First of all, thanks for this amazing plugin! And I personally think that map syncing feature is great too. However, I found some disadvantages of current implementation.

- Maps stop tracking position after player goes back to original world
- Having several copies of the same map in different slots causes it to be saved several times
- Maps in shulkers and bundles are not synced
- Saving map pixels in items directly makes snapshots quite big

This PR tries to address these issues by creating two additional tables, one saves map data, the other saves old and new world and map IDs to properly convert them.

The code was tested with PostgreSQL and MySQL.