### PR TITLE
fix: enable the userdata view command with no snapshot uuid args

### DIFF
--- a/common/src/main/java/net/william278/husksync/command/UserDataCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/UserDataCommand.java
@@ -215,11 +215,17 @@ public class UserDataCommand extends PluginCommand {
 
     @NotNull
     private CommandProvider view() {
-        return (sub) -> sub.addSyntax((ctx) -> {
-            final User user = ctx.getArgument("username", User.class);
-            final UUID version = ctx.getArgument("version", UUID.class);
-            viewSnapshot(user(sub, ctx), user, version);
-        }, user("username"), versionUuid());
+        return (sub) -> {
+            sub.addSyntax((ctx) -> {
+                final User user = ctx.getArgument("username", User.class);
+                final UUID version = ctx.getArgument("version", UUID.class);
+                viewSnapshot(user(sub, ctx), user, version);
+            }, user("username"), versionUuid());
+            sub.addSyntax((ctx) -> {
+                final User user = ctx.getArgument("username", User.class);
+                viewLatestSnapshot(user(sub, ctx), user);
+            }, user("username"));
+        };
     }
 
     @NotNull


### PR DESCRIPTION
Hi there! 
I was reading the documentation https://github.com/WiIIiam278/HuskSync/blob/9ee8ea1c849ce24d0e8ca8af9ebf9c190e0f1b75/docs/Data-Rotation.md?plain=1#L26 and after trying to run the userdata view command I saw it was not working.

I don't assume I'm correct, so you can tell me. I spent some time figuring out how it worked, since I'm not familiar with plugin development. 😅

I saw that it had a ready method for it, unused, so it got me a bit confused