### PR TITLE
fix: handle ender chest size mismatch

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
@@ -199,7 +199,9 @@ public abstract class BukkitData implements Data {
 
             @Override
             public void apply(@NotNull BukkitUser user, @NotNull BukkitHuskSync plugin) throws IllegalStateException {
-                user.getPlayer().getEnderChest().setContents(plugin.setMapViews(getContents()));
+                ItemStack[] fullContents = plugin.setMapViews(getContents());
+                ItemStack[] enderChestContents = Arrays.copyOf(fullContents, Math.min(fullContents.length, user.getPlayer().getEnderChest().getSize()));
+                user.getPlayer().getEnderChest().setContents(enderChestContents);
             }
 
         }


### PR DESCRIPTION
Purpur allows you to change the count of rows in the enderchest from 1 to 6 with `settings.ender_chest.six-rows: true`. If the player currently has fewer rows than in the snapshot, HuskSync will not be able to load it due to an error. This PR fixes  the issue by cropping the content.