### PR TITLE
feat: allow overriding server name via HUSKSYNC_SERVER_NAME env

### DIFF
--- a/common/src/main/java/net/william278/husksync/config/Server.java
+++ b/common/src/main/java/net/william278/husksync/config/Server.java
@@ -22,13 +22,11 @@ package net.william278.husksync.config;
 import de.exlll.configlib.Configuration;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.file.Path;
 
-@Getter
 @Configuration
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -66,5 +64,9 @@ public class Server {
         }
         return super.equals(other);
     }
-
+  
+    public String getName() {
+        final String envServerName = System.getenv("HUSKSYNC_SERVER_NAME");
+        return envServerName == null ? name : envServerName;
+    }
 }


### PR DESCRIPTION
This is useful when using docker.