### PR TITLE
Fix MongoDB getMapBinding and clarify Javadoc

### DIFF
--- a/common/src/main/java/net/william278/husksync/database/Database.java
+++ b/common/src/main/java/net/william278/husksync/database/Database.java
@@ -280,11 +280,11 @@ public abstract class Database {
     public abstract byte @Nullable [] getMapData(@NotNull String serverName, int mapId);
 
     /**
-     * Get a map server -> ID binding in the database
+     * Reverse lookup: given a local map binding, find the origin server and map ID.
      *
-     * @param serverName Name of the server the map originates from
-     * @param mapId      Original map ID
-     * @return Map.Entry (key: server name, value: map ID)
+     * @param serverName Name of the local server (to_server_name in the binding)
+     * @param mapId      Local map ID on this server (to_id in the binding)
+     * @return Map.Entry with origin server name (key) and origin map ID (value), or null if not found
      */
     @Blocking
     public abstract @Nullable Map.Entry<String, Integer> getMapBinding(@NotNull String serverName, int mapId);

--- a/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
+++ b/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java
@@ -399,8 +399,8 @@ public class MongoDbDatabase extends Database {
         final Document doc = iterable.first();
         if (doc != null) {
             return new AbstractMap.SimpleImmutableEntry<>(
-                    doc.getString("server_name"),
-                    doc.getInteger("to_id")
+                    doc.getString("from_server_name"),
+                    doc.getInteger("from_id")
             );
         }
         return null;


### PR DESCRIPTION
## Summary
[getMapBinding()](https://github.com/WiIIiam278/HuskSync/blob/b1a5eb5f44a96ca1a1b34b66ff62b40dada560f2/common/src/main/java/net/william278/husksync/database/MongoDbDatabase.java#L396) in MongoDbDatabase reads incorrect field names, causing reverse map binding lookups to fail for MongoDB users. Javadoc is quite misleading also, when all implementations actually filter (to_server_name, to_id) and return (from_server_name, from_id).

## Bug
The method filters by `to_server_name` and `to_id` (correct), but returns:
- `doc.getString("server_name")` → should be `"from_server_name"`
- `doc.getInteger("to_id")` → should be `"from_id"`

## Impact
- `"server_name"` field doesn't exist in the document, returns `null`
- Returns the local map ID instead of the origin map ID
- Breaks reverse lookup for locked maps on MongoDB setups

## Fix
Align MongoDB with MySQL/PostgreSQL implementations by reading the correct fields.