### PR TITLE
Align data versions: DataVersionSupplier ↔ NBT-API-DataFixerUtil

### DIFF
--- a/common/src/main/java/net/william278/husksync/util/DataVersionSupplier.java
+++ b/common/src/main/java/net/william278/husksync/util/DataVersionSupplier.java
@@ -34,15 +34,12 @@ public interface DataVersionSupplier {
     int VERSION1_20_2 = 3578;
     int VERSION1_20_4 = 3700;
     int VERSION1_20_5 = 3837;
-    int VERSION1_21_1 = 3955;
-    int VERSION1_21_3 = 4082;
+    int VERSION1_21_1 = 3953;
+    int VERSION1_21_3 = 4080;
     int VERSION1_21_4 = 4189;
     int VERSION1_21_5 = 4323;
-    int VERSION1_21_6 = 4435;
-    int VERSION1_21_7 = 4438;
-    int VERSION1_21_8 = 4438;
-    int VERSION1_21_9 = 4554;
-    int VERSION1_21_10 = 4556;
+    int VERSION1_21_8 = 4435;
+    int VERSION1_21_10 = 4554;
     int VERSION1_21_11 = 4671;
 
     /**
@@ -66,11 +63,8 @@ public interface DataVersionSupplier {
             case "1.21.2", "1.21.3" -> VERSION1_21_3;
             case "1.21.4" -> VERSION1_21_4;
             case "1.21.5" -> VERSION1_21_5;
-            case "1.21.6" -> VERSION1_21_6;
-            case "1.21.7" -> VERSION1_21_7;
-            case "1.21.8" -> VERSION1_21_8;
-            case "1.21.9" -> VERSION1_21_9;
-            case "1.21.10" -> VERSION1_21_10;
+            case "1.21.6", "1.21.7", "1.21.8" -> VERSION1_21_8;
+            case "1.21.9", "1.21.10" -> VERSION1_21_10;
             case "1.21.11" -> VERSION1_21_11;
             default -> VERSION1_21_11; // Latest supported version
         };


### PR DESCRIPTION
https://github.com/WiIIiam278/HuskSync/blob/ac163d51302d8edaef08885276283001e20f4b94/bukkit/src/main/java/net/william278/husksync/data/BukkitSerializer.java#L156-L160

The data version in HuskSync-DataVersionSupplier may be higher than that in NBTAPI-DataFixerUtil. For example, in version 1.21.8, the data version of HuskSync is 4438, while that of [NBTAPI](https://github.com/tr7zw/Item-NBT-API/blob/master/item-nbt-api/src/main/java/de/tr7zw/changeme/nbtapi/utils/DataFixerUtil.java) is 4435.

There may be a check in subsequent conversions that directly returns the original data when fromVersion >= toVersion, but I'm not certain.