### PR TITLE
fix: Change hardcoded map scale from NORMAL to CLOSEST to prevent unwanted markers

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/maps/BukkitMapHandler.java
+++ b/bukkit/src/main/java/net/william278/husksync/maps/BukkitMapHandler.java
@@ -342,7 +342,7 @@ public interface BukkitMapHandler {
             view.getRenderers().clear();
             view.getRenderers().addAll(optionalView.get().getRenderers());
             view.setLocked(true);
-            view.setScale(MapView.Scale.NORMAL);
+            view.setScale(MapView.Scale.CLOSEST);
             view.setTrackingPosition(false);
             view.setUnlimitedTracking(false);
             return;
@@ -377,7 +377,7 @@ public interface BukkitMapHandler {
         view.getRenderers().clear();
         view.addRenderer(new PersistentMapRenderer(canvasData));
         view.setLocked(true);
-        view.setScale(MapView.Scale.NORMAL);
+        view.setScale(MapView.Scale.CLOSEST);
         view.setTrackingPosition(false);
         view.setUnlimitedTracking(false);
         setMapView(view);
@@ -603,7 +603,7 @@ public interface BukkitMapHandler {
                 }
 
             }
-            return MapData.fromPixels(mapDataVersion, pixels, getDimension(), (byte) 2, banners, List.of());
+            return MapData.fromPixels(mapDataVersion, pixels, getDimension(), (byte) 0, banners, List.of());
         }
     }
 


### PR DESCRIPTION
## Problem
Locked maps synced across servers were displaying unwanted green item frame markers and appearing at 1:4 scale even when originally created at 1:1 scale. The map pixel content remained correct, but the scale metadata was being forced to NORMAL (1:4), causing Minecraft to detect item frames within a 512×512 block range instead of the original 128×128.

## Cause
Map scale was hardcoded to `MapView.Scale.NORMAL` (1:4) in three places:
- `extractMapData()` - when saving map data
- `renderMapView()` - when restoring maps
- `renderInitializingLockedMap()` - when rendering maps in item frames

## Fix
Changed all hardcoded scale values from NORMAL (1:4, 512×512 blocks) to CLOSEST (1:1, 128×128 blocks).

This reduces the item frame detection range, preventing green markers from appearing on locked maps that were originally created at 1:1 scale.

## Note
An alternative approach would be to preserve the original map scale dynamically. However, existing maps already stored in the database have `scale=2` (NORMAL) baked into their data. Hardcoding to CLOSEST fixes both old and new maps immediately, whereas preserving original scale would only fix newly synced maps going forward.