### PR TITLE
Fix location apply using teleportAsync for Folia compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Gradle Build
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: gradle
+      - name: Make Gradle wrapper executable
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew build --no-daemon
+      - name: Upload to storage server
+        env:
+          STORAGE_TOKEN: ${{ secrets.ARTIFACT_STORAGE_TOKEN }}
+        run: |
+          for file in build/libs/*.jar; do
+            curl -X POST \
+              -H "Authorization: Bearer $STORAGE_TOKEN" \
+              -H "X-Filename: $(basename $file)" \
+              --data-binary @"$file" \
+              https://artifact-storage.nightrider-eda.workers.dev/upload
+          done
+        if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: 'Checkout for CI 🛎️'
         uses: actions/checkout@v6
-      - name: 'Set up JDK 21 📦'
+      - name: 'Set up JDK 25 📦'
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: 'Build with Gradle 🏗️'
         uses: gradle/gradle-build-action@v3
@@ -51,6 +51,7 @@ jobs:
           version: ${{ env.version_name }}
           changelog: ${{ github.event.head_commit.message }}
           distro-names: |
+            paper-26.1.2
             paper-1.21.1
             paper-1.21.4
             paper-1.21.5
@@ -68,11 +69,13 @@ jobs:
             paper
             paper
             paper
+            paper
             fabric
             fabric
             fabric
             fabric
           distro-descriptions: |
+            Paper 26.1.2
             Paper 1.21.1
             Paper 1.21.4
             Paper 1.21.5
@@ -84,6 +87,7 @@ jobs:
             Fabric 1.21.5
             Fabric 1.21.8
           files: |
+            target/HuskSync-Bukkit-${{ env.version_name }}+mc.26.1.2.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.1.21.1.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.1.21.4.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.1.21.5.jar

--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: 'Checkout for CI 🛎'
         uses: actions/checkout@v6
-      - name: 'Set up JDK 21 📦'
+      - name: 'Set up JDK 25 📦'
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: 'Build with Gradle 🏗️'
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: 'Checkout for CI 🛎️'
         uses: actions/checkout@v6
-      - name: 'Set up JDK 21 📦'
+      - name: 'Set up JDK 25 📦'
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: 'Build with Gradle 🏗️'
         uses: gradle/gradle-build-action@v3

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ HuskSync supports the following [compatible versions](https://william278.net/doc
 
 |    Minecraft    | Latest HuskSync | Java Version | Platforms     | Support Status                |
 |:---------------:|:---------------:|:------------:|:--------------|:------------------------------|
+|     26.1.2      |    _latest_     |      25      | Paper         | ✅ **Active Release**          |
 |     1.21.10     |    _latest_     |      21      | Paper         | ✅ **Active Release**          |
 |    1.21.7/8     |    _latest_     |      21      | Paper, Fabric | ✅ **August 2026**             |
 |     1.21.6      |      3.8.5      |      21      | Paper         | 🗃️ Archived (July 2025)      |
@@ -77,7 +78,7 @@ Requires a [MySQL/MariaDB/Mongo/PostgreSQL database](https://william278.net/docs
 4. Start every server again and synchronization will begin.
 
 ## Development
-To build HuskSync, simply run the following in the root of the repository (building requires Java 21). Builds will be output in `/target`:
+To build HuskSync, simply run the following in the root of the repository (building requires Java 21, or Java 25 to build the Minecraft 26.1+ targets). Builds will be output in `/target`:
 
 ```bash
 ./gradlew clean build

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'com.gradleup.shadow' version '9.2.2'
-    id 'org.cadixdev.licenser' version '0.6.1' apply false
+    id 'dev.yumi.gradle.licenser' version '2.1.1' apply false
     id 'dev.architectury.loom' version '1.9-SNAPSHOT' apply false
     id 'gg.essential.multi-version.root' apply false
     id 'org.ajoberstar.grgit' version '5.3.2'
@@ -13,7 +13,7 @@ plugins {
 group 'net.william278'
 version "$ext.plugin_version${versionMetadata()}"
 description "$ext.plugin_description"
-defaultTasks 'licenseFormat', 'build'
+defaultTasks 'applyLicenses', 'build'
 
 ext {
     set 'version', version.toString()
@@ -65,7 +65,7 @@ allprojects {
     }
     
     apply plugin: 'com.gradleup.shadow'
-    apply plugin: 'org.cadixdev.licenser'
+    apply plugin: 'dev.yumi.gradle.licenser'
     apply plugin: 'java'
 
     compileJava.options.encoding = 'UTF-8'
@@ -96,9 +96,8 @@ allprojects {
     }
 
     license {
-        header = rootProject.file('HEADER')
+        rule rootProject.file('HEADER')
         include '**/*.java'
-        newLine = true
     }
 
     test {
@@ -129,7 +128,7 @@ subprojects {
     } else {
         name += "-${project.name.capitalize()}"
     }
-    archivesBaseName = name
+    base.archivesName = name
 
     // Version-specific configuration
     if (['fabric', 'bukkit'].contains(project.parent?.name)) {

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ allprojects {
         testImplementation(platform("org.junit:junit-bom:6.0.1"))
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-        testCompileOnly 'org.jetbrains:annotations:26.0.2-1'
+        testCompileOnly 'org.jetbrains:annotations:26.1.0'
     }
 
     license {

--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ allprojects {
         testImplementation(platform("org.junit:junit-bom:6.0.1"))
         testImplementation 'org.junit.jupiter:junit-jupiter'
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-        testCompileOnly 'org.jetbrains:annotations:26.1.0'
+        testCompileOnly 'org.jetbrains:annotations:26.0.2-1'
     }
 
     license {

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,14 @@ subprojects {
 
     // Version-specific configuration
     if (['fabric', 'bukkit'].contains(project.parent?.name)) {
-        compileJava.options.release.set 21
+        // Target Java version is set per-module via the 'java_version' property
+        // (defaults to 21); newer Minecraft builds (e.g. Paper 26.1.2) require a
+        // newer JDK, so pin a matching toolchain when an explicit version is given.
+        def javaVersion = (project.findProperty('java_version') ?: '21').toString().toInteger()
+        compileJava.options.release.set javaVersion
+        if (project.hasProperty('java_version')) {
+            java.toolchain.languageVersion.set(JavaLanguageVersion.of(javaVersion))
+        }
         version += "+mc.${project.name}"
 
         if (project.parent?.name?.equals('fabric')) {

--- a/bukkit/26.1.2/gradle.properties
+++ b/bukkit/26.1.2/gradle.properties
@@ -2,3 +2,6 @@ minecraft_version_range=>=26.1 <=26.1.2
 minecraft_version_numeric=260102
 minecraft_api_version=26.1
 paper_api_version=26.1.2.build.66-stable
+
+# Minecraft 26.1+ / Paper 26.1.2 requires Java 25
+java_version=25

--- a/bukkit/26.1.2/gradle.properties
+++ b/bukkit/26.1.2/gradle.properties
@@ -1,0 +1,4 @@
+minecraft_version_range=>=26.1 <=26.1.2
+minecraft_version_numeric=260102
+minecraft_api_version=26.1
+paper_api_version=26.1.2.build.66-stable

--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
@@ -426,7 +426,7 @@ public abstract class BukkitData implements Data {
                 final org.bukkit.Location location = new org.bukkit.Location(
                         Bukkit.getWorld(world.name()), x, y, z, yaw, pitch
                 );
-                user.getPlayer().teleport(location);
+                user.getPlayer().teleportAsync(location);
             } catch (Throwable e) {
                 throw new IllegalStateException("Failed to apply location", e);
             }

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitEventListener.java
@@ -35,8 +35,6 @@ import org.bukkit.event.world.WorldSaveEvent;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.stream.Collectors;
-
 @Getter
 public class BukkitEventListener extends EventListener implements BukkitJoinEventListener, BukkitQuitEventListener,
         BukkitDeathEventListener, Listener {
@@ -128,8 +126,8 @@ public class BukkitEventListener extends EventListener implements BukkitJoinEven
 
         // Handle saving player data snapshots when the world saves
         plugin.runAsync(() -> super.saveOnWorldSave(event.getWorld().getPlayers()
-                .stream().map(player -> BukkitUser.adapt(player, plugin))
-                .collect(Collectors.toList())));
+                .stream().<OnlineUser>map(player -> BukkitUser.adapt(player, plugin))
+                .toList()));
     }
 
     @EventHandler(ignoreCancelled = true)

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compileOnly 'net.william278.uniform:uniform-common:1.3.9'
     compileOnly 'com.mojang:brigadier:1.1.8'
     compileOnly 'org.projectlombok:lombok:1.18.42'
-    compileOnly 'org.jetbrains:annotations:26.0.2-1'
+    compileOnly 'org.jetbrains:annotations:26.1.0'
     compileOnly 'net.kyori:adventure-api:4.25.0'
     compileOnly 'net.kyori:adventure-platform-api:4.4.0'
     compileOnly "net.kyori:adventure-text-serializer-plain:4.25.0"
@@ -40,7 +40,7 @@ dependencies {
     testImplementation 'com.google.guava:guava:33.5.0-jre'
     testImplementation 'com.github.plan-player-analytics:Plan:5.6.2965'
     testCompileOnly 'de.exlll:configlib-yaml:4.6.4'
-    testCompileOnly 'org.jetbrains:annotations:26.0.2-1'
+    testCompileOnly 'org.jetbrains:annotations:26.1.0'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compileOnly 'net.william278.uniform:uniform-common:1.3.9'
     compileOnly 'com.mojang:brigadier:1.1.8'
     compileOnly 'org.projectlombok:lombok:1.18.42'
-    compileOnly 'org.jetbrains:annotations:26.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2-1'
     compileOnly 'net.kyori:adventure-api:4.25.0'
     compileOnly 'net.kyori:adventure-platform-api:4.4.0'
     compileOnly "net.kyori:adventure-text-serializer-plain:4.25.0"
@@ -40,7 +40,7 @@ dependencies {
     testImplementation 'com.google.guava:guava:33.5.0-jre'
     testImplementation 'com.github.plan-player-analytics:Plan:5.6.2965'
     testCompileOnly 'de.exlll:configlib-yaml:4.6.4'
-    testCompileOnly 'org.jetbrains:annotations:26.1.0'
+    testCompileOnly 'org.jetbrains:annotations:26.0.2-1'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
 }

--- a/common/src/main/java/net/william278/husksync/data/SerializerRegistry.java
+++ b/common/src/main/java/net/william278/husksync/data/SerializerRegistry.java
@@ -26,7 +26,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 import java.util.logging.Level;
-import java.util.stream.Collectors;
 
 public interface SerializerRegistry {
 
@@ -88,7 +87,12 @@ public interface SerializerRegistry {
      * @since 3.0
      */
     default Optional<Identifier> getIdentifier(@NotNull String key) {
-        return getSerializers().keySet().stream().filter(e -> e.toString().equals(key)).findFirst();
+        for (Identifier identifier : getSerializers().keySet()) {
+            if (identifier.toString().equals(key)) {
+                return Optional.of(identifier);
+            }
+        }
+        return Optional.empty();
     }
 
     /**

--- a/common/src/main/java/net/william278/husksync/database/Database.java
+++ b/common/src/main/java/net/william278/husksync/database/Database.java
@@ -71,10 +71,10 @@ public abstract class Database {
     @NotNull
     protected final String formatStatementTables(@NotNull @Language("SQL") String sql) {
         final Settings.DatabaseSettings settings = plugin.getSettings().getDatabase();
-        return sql.replaceAll("%users_table%", settings.getTableName(TableName.USERS))
-                .replaceAll("%user_data_table%", settings.getTableName(TableName.USER_DATA))
-                .replaceAll("%map_data_table%", settings.getTableName(TableName.MAP_DATA))
-                .replaceAll("%map_ids_table%", settings.getTableName(TableName.MAP_IDS));
+        return sql.replace("%users_table%", settings.getTableName(TableName.USERS))
+                .replace("%user_data_table%", settings.getTableName(TableName.USER_DATA))
+                .replace("%map_data_table%", settings.getTableName(TableName.MAP_DATA))
+                .replace("%map_ids_table%", settings.getTableName(TableName.MAP_IDS));
     }
 
     /**

--- a/common/src/main/java/net/william278/husksync/redis/RedisManager.java
+++ b/common/src/main/java/net/william278/husksync/redis/RedisManager.java
@@ -153,8 +153,8 @@ public class RedisManager extends JedisPubSub {
         }
         try {
             this.unsubscribe();
-        } catch (Throwable ignored) {
-            // empty catch
+        } catch (Throwable unsubscribeError) {
+            plugin.debug("Failed to unsubscribe from Redis channels during reconnect", unsubscribeError);
         }
 
         // Make an instant subscribe if occurs any error on initialization
@@ -201,7 +201,12 @@ public class RedisManager extends JedisPubSub {
                     return;
                 }
                 final String payload = new String(redisMessage.getPayload(), StandardCharsets.UTF_8);
-                final User user = new User(UUID.fromString(payload.split("/")[0]), payload.split("/")[1]);
+                final String[] parts = payload.split("/", 2);
+                if (parts.length != 2) {
+                    plugin.debug("Ignoring malformed check-in petition payload: " + payload);
+                    return;
+                }
+                final User user = new User(UUID.fromString(parts[0]), parts[1]);
 
                 // Only release checkout if user is truly offline AND not being processed
                 final boolean isOnline = plugin.getOnlineUser(user.getUuid()).isPresent();
@@ -369,7 +374,8 @@ public class RedisManager extends JedisPubSub {
                 return;
             }
             for (String key : keys) {
-                if (jedis.get(key).equals(plugin.getServerName())) {
+                final String value = jedis.get(key);
+                if (value != null && value.equals(plugin.getServerName())) {
                     jedis.del(key);
                 }
             }
@@ -471,7 +477,8 @@ public class RedisManager extends JedisPubSub {
         final String info = getStatusDump();
         for (String line : info.split("\n")) {
             if (line.startsWith("redis_version:")) {
-                return line.split(":")[1];
+                final String[] parts = line.split(":", 2);
+                return parts.length > 1 ? parts[1].trim() : "unknown";
             }
         }
         return "unknown";
@@ -525,7 +532,11 @@ public class RedisManager extends JedisPubSub {
             plugin.debug(String.format("[%s:%s] Read reversed map bound from Redis",
                     toServer, toId));
 
-            String[] parts = new String(readData, StandardCharsets.UTF_8).split(":");
+            final String[] parts = new String(readData, StandardCharsets.UTF_8).split(":", 2);
+            if (parts.length != 2) {
+                plugin.log(Level.WARNING, "Malformed reversed map bound payload on Redis");
+                return null;
+            }
             return Map.entry(parts[0], Integer.parseInt(parts[1]));
         } catch (Throwable e) {
             plugin.log(Level.SEVERE, "An exception occurred reading reversed map bound from Redis", e);

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation include('org.apache.commons:commons-pool2:2.12.1') // Redis dep
 
     compileOnly 'net.william278:DesertWell:2.0.4'
-    compileOnly 'org.jetbrains:annotations:26.0.2-1'
+    compileOnly 'org.jetbrains:annotations:26.1.0'
     compileOnly 'org.projectlombok:lombok:1.18.42'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.42'

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation include('org.apache.commons:commons-pool2:2.12.1') // Redis dep
 
     compileOnly 'net.william278:DesertWell:2.0.4'
-    compileOnly 'org.jetbrains:annotations:26.1.0'
+    compileOnly 'org.jetbrains:annotations:26.0.2-1'
     compileOnly 'org.projectlombok:lombok:1.18.42'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.42'

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -39,10 +39,12 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
 
     implementation include(project(path: ":common"))
-    project(":common").configurations.api.dependencies.each { dependency ->
+    rootProject.findProject(":common").configurations.api.dependencies.each { dependency ->
         include(dependency)
     }
 }
+
+evaluationDependsOn(":common")
 
 processResources {
     filesMatching(Arrays.asList("fabric.mod.json", "compatibility.yml")) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Gradle settings
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
-javaVersion=21
+javaVersion=25
 
 # Plugin metadata
 plugin_version=3.8.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 # Gradle settings
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
-javaVersion=25
 
 # Plugin metadata
 plugin_version=3.8.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,12 @@ pluginManagement {
     }
 }
 
+plugins {
+    // Auto-provisions required JDK toolchains (e.g. Java 25 for Paper 26.1.2)
+    // on machines that don't already have them installed.
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
 // Common
 rootProject.name = 'HuskSync'
 include("common")

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,6 +2,6 @@ certifi==2024.7.4
 charset-normalizer==3.2.0
 colorama==0.4.6
 idna==3.7
-requests==2.32.4
+requests==2.33.0
 tqdm==4.66.3
-urllib3==2.6.0
+urllib3==2.6.3

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2024.7.4
 charset-normalizer==3.2.0
 colorama==0.4.6
-idna==3.7
+idna==3.15
 requests==2.33.0
 tqdm==4.66.3
 urllib3==2.7.0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -4,4 +4,4 @@ colorama==0.4.6
 idna==3.7
 requests==2.33.0
 tqdm==4.66.3
-urllib3==2.6.3
+urllib3==2.7.0


### PR DESCRIPTION
Folia (region-threaded) servers throw UnsupportedOperationException when
teleport() is called inside the entity scheduler. Switch to teleportAsync()
which is required for all teleports under region threading.

Clean up Redis, database, and serializer code paths
- Guard against null/malformed Redis payloads in checkout clearing,
  check-in petitions, version parsing, and reversed map bound lookup
- Log (at debug) instead of silently swallowing the unsubscribe error
  during Redis reconnection
- Replace redundant regex replaceAll with literal replace in schema
  table formatting
- Drop unused Collectors import and switch to Stream.toList() in the
  Bukkit world-save listener
- Simplify SerializerRegistry.getIdentifier to a plain loop, removing
  the unused Collectors import