### PR TITLE
fix: reduce latest_snapshot Redis TTL from 1 year to 7 days

### DIFF
--- a/common/src/main/java/net/william278/husksync/redis/RedisKeyType.java
+++ b/common/src/main/java/net/william278/husksync/redis/RedisKeyType.java
@@ -33,6 +33,7 @@ public enum RedisKeyType {
     MAP_DATA;
 
     public static final int TTL_1_YEAR = 60 * 60 * 24 * 7 * 52; // 1 year
+    public static final int TTL_7_DAYS = 60 * 60 * 24 * 7; // 7 days
     public static final int TTL_10_SECONDS = 10; // 10 seconds
 
     @NotNull

--- a/common/src/main/java/net/william278/husksync/redis/RedisManager.java
+++ b/common/src/main/java/net/william278/husksync/redis/RedisManager.java
@@ -299,7 +299,7 @@ public class RedisManager extends JedisPubSub {
         try (Jedis jedis = jedisPool.getResource()) {
             jedis.setex(
                     getKey(RedisKeyType.LATEST_SNAPSHOT, user.getUuid(), clusterId),
-                    RedisKeyType.TTL_1_YEAR,
+                    RedisKeyType.TTL_7_DAYS,
                     data.asBytes(plugin));
             plugin.debug(String.format("[%s] Set %s key on Redis", user.getName(), RedisKeyType.LATEST_SNAPSHOT));
         } catch (Throwable e) {


### PR DESCRIPTION
## Problem

`RedisKeyType.TTL_1_YEAR` (31,449,600 s ≈ 364 days) is used for the `LATEST_SNAPSHOT` key in `RedisManager.setUserData()`. This key is a **transient, single-use cache** written when a player switches servers and consumed (deleted) when the destination server applies the snapshot on join.

Because the key is almost always consumed within seconds, assigning a 1-year TTL means keys from crashed or disconnected sessions are never evicted. In production this causes Redis to silently accumulate tens of thousands of stale keys over time, growing memory unboundedly.

Fixes #647

## Fix

Add a `TTL_7_DAYS` constant (604,800 s) and use it for the `LATEST_SNAPSHOT` key.  
Map-related keys (`bindMapIds`, `setMapData`) intentionally keep `TTL_1_YEAR` since map ID bindings need long-term persistence.

## Changes

| File | Change |
|---|---|
| `RedisKeyType.java` | Add `TTL_7_DAYS = 60 * 60 * 24 * 7` |
| `RedisManager.java` | `setUserData()`: `TTL_1_YEAR` → `TTL_7_DAYS` |

## Testing

After applying: observe new `LATEST_SNAPSHOT` keys in Redis — their TTL should report ~604,800 s instead of ~31,449,600 s.