### PR TITLE
perf: pre-filter materials for statistics to reduce CPU spike on sync

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
@@ -439,6 +439,28 @@ public abstract class BukkitData implements Data {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Statistics extends BukkitData implements Data.Statistics, Adaptable {
 
+        // Pre-filtered material lists to avoid N×M iteration over the full Registry.MATERIAL per statistic type
+        private static Set<Material> BLOCK_MATERIALS;
+        private static Set<Material> ITEM_MATERIALS;
+
+        private static Set<Material> getBlockMaterials() {
+            if (BLOCK_MATERIALS == null) {
+                final Set<Material> blocks = new HashSet<>();
+                Registry.MATERIAL.forEach(mat -> { if (mat.isBlock()) blocks.add(mat); });
+                BLOCK_MATERIALS = Collections.unmodifiableSet(blocks);
+            }
+            return BLOCK_MATERIALS;
+        }
+
+        private static Set<Material> getItemMaterials() {
+            if (ITEM_MATERIALS == null) {
+                final Set<Material> items = new HashSet<>();
+                Registry.MATERIAL.forEach(mat -> { if (mat.isItem()) items.add(mat); });
+                ITEM_MATERIALS = Collections.unmodifiableSet(items);
+            }
+            return ITEM_MATERIALS;
+        }
+
         @SerializedName("generic")
         private Map<String, Integer> genericStatistics;
         @SerializedName("blocks")
@@ -457,8 +479,8 @@ public abstract class BukkitData implements Data {
                 switch (id.getType()) {
                     case UNTYPED -> addStatistic(player, id, generic);
                     // Todo - Future - Use BLOCK and ITEM registries when API stabilizes
-                    case BLOCK -> addStatistic(player, id, Registry.MATERIAL, blocks);
-                    case ITEM -> addStatistic(player, id, Registry.MATERIAL, items);
+                    case BLOCK -> addStatistic(player, id, getBlockMaterials(), blocks);
+                    case ITEM -> addStatistic(player, id, getItemMaterials(), items);
                     case ENTITY -> addStatistic(player, id, Registry.ENTITY_TYPE, entities);
                 }
             });
@@ -481,7 +503,7 @@ public abstract class BukkitData implements Data {
         }
 
         private static <R extends Keyed> void addStatistic(@NotNull Player p, @NotNull Statistic id,
-                                                           @NotNull Registry<R> registry,
+                                                           @NotNull Iterable<R> registry,
                                                            @NotNull Map<String, Map<String, Integer>> map) {
             registry.forEach(i -> {
                 try {


### PR DESCRIPTION
## Problem

Statistics.adapt() iterates all BLOCK/ITEM statistics x all Registry.MATERIAL entries (hundreds), calling mat.isBlock() or mat.isItem() inline. With N statistics types and M materials, this is O(N*M) per player sync, causing CPU spikes to 100% when multiple players connect at startup.

Fixes #588

## Fix

Cache a filtered block-only and item-only set of Registry.MATERIAL on first use. Pass these pre-filtered sets to addStatistic() instead of the full registry. Change addStatistic() registry parameter from Registry<R> to Iterable<R>.

## Changes

BukkitData.java (Statistics class):
- Add BLOCK_MATERIALS / ITEM_MATERIALS static caches with lazy initialization
- Update adapt() to call getBlockMaterials() / getItemMaterials()
- Change addStatistic() parameter to Iterable<R>