### PR TITLE
fix: gracefully skip corrupted data types when loading a snapshot

### DIFF
--- a/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
+++ b/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -390,15 +391,23 @@ public class DataSnapshot {
         @NotNull
         @ApiStatus.Internal
         private Map<Identifier, Data> deserializeData(@NotNull HuskSync plugin) {
-            return data.entrySet().stream()
+            final Map<Identifier, Data> result = new HashMap<>();
+            data.entrySet().stream()
                     .filter(e -> plugin.getIdentifier(e.getKey()).isPresent())
                     .map(entry -> Map.entry(plugin.getIdentifier(entry.getKey()).orElseThrow(), entry.getValue()))
-                    .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            entry -> plugin.deserializeData(entry.getKey(), entry.getValue(), getMinecraftVersion()),
-                            (a, b) -> a,
-                            HashMap::new
-                    ));
+                    .forEach(entry -> {
+                        try {
+                            result.put(entry.getKey(), plugin.deserializeData(
+                                    entry.getKey(), entry.getValue(), getMinecraftVersion()));
+                        } catch (Throwable e) {
+                            plugin.log(Level.WARNING,
+                                    "Failed to deserialize %s data for snapshot %s; skipping it. "
+                                            + "The data may contain invalid values (e.g. items with -Infinity NBT attributes). "
+                                            + "The player will load without this data type for this session."
+                                            .formatted(entry.getKey(), getId()), e);
+                        }
+                    });
+            return result;
         }
 
         @NotNull


### PR DESCRIPTION
## Problem

When a snapshot contains a data type with invalid NBT values (specifically items with `-Infinity` or `Infinity` as attribute amounts), `NBT.parseNBT()` throws because Minecraft's SNBT parser does not recognise `-Infinityd` as a valid literal, even though Java's `double` supports it.

This causes the entire snapshot deserialization to abort, and the player is permanently locked out of the server until an admin manually deletes the snapshot.

The error observed in production:
```
NbtApiException: Unable to parse Malformed Json!
Caused by: CommandSyntaxException: Expected literal ( at position 120: ...-Infinityd<--[HERE]
```

Relates to #584

## Fix

Wrap the per-entry `plugin.deserializeData()` call in `Unpacked.deserializeData()` in a try-catch. On failure, log a `WARNING` with the snapshot ID and data type name, and skip that entry. The player loads with all other data types intact (health, XP, advancements, etc.) and the corrupted type is omitted for that session rather than blocking login entirely.

## Changes

| File | Change |
|---|---|
| `DataSnapshot.java` | Add `import java.util.logging.Level`; replace `Collectors.toMap()` stream with an iterative forEach + try-catch per entry |

## Notes

- No data is deleted; the corrupted snapshot remains in the database and is still accessible to admins via `/userdata`
- The warning message explicitly names the data type and snapshot ID for easy triage
- Items that triggered the corruption (third-party plugin custom items with `-Infinity` attribute values) will simply not appear in the player's inventory for that session