### PR TITLE
fix: prevent item duplication on server shutdown (#654)

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
+++ b/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
@@ -238,7 +238,7 @@ public class BukkitHuskSync extends JavaPlugin implements HuskSync, BukkitTask.S
         this.disabling = true;
 
         // 1. Complete all player saves (including in-flight async saves from PlayerQuitEvent)
-        //    and close DB/Redis connections. Must run before terminate() clears Redis checkout
+        //    and close DB connections. Must run before terminate() clears Redis checkout
         //    keys, otherwise Server B may read a stale LATEST_SNAPSHOT (fix for #654).
         if (this.eventListener != null) {
             this.eventListener.handlePluginDisable();
@@ -247,6 +247,11 @@ public class BukkitHuskSync extends JavaPlugin implements HuskSync, BukkitTask.S
         // 2. Clear Redis checkout state after snapshots are correctly persisted
         if (this.dataSyncer != null) {
             this.dataSyncer.terminate();
+        }
+
+        // 3. Close Redis after checkout keys are cleared (must be last)
+        if (this.redisManager != null) {
+            this.redisManager.terminate();
         }
 
         // Unregister API and cancel tasks

--- a/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
+++ b/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
@@ -237,12 +237,16 @@ public class BukkitHuskSync extends JavaPlugin implements HuskSync, BukkitTask.S
         // Handle shutdown
         this.disabling = true;
 
-        // Close the event listener / data syncer
-        if (this.dataSyncer != null) {
-            this.dataSyncer.terminate();
-        }
+        // 1. Complete all player saves (including in-flight async saves from PlayerQuitEvent)
+        //    and close DB/Redis connections. Must run before terminate() clears Redis checkout
+        //    keys, otherwise Server B may read a stale LATEST_SNAPSHOT (fix for #654).
         if (this.eventListener != null) {
             this.eventListener.handlePluginDisable();
+        }
+
+        // 2. Clear Redis checkout state after snapshots are correctly persisted
+        if (this.dataSyncer != null) {
+            this.dataSyncer.terminate();
         }
 
         // Unregister API and cancel tasks

--- a/common/src/main/java/net/william278/husksync/listener/EventListener.java
+++ b/common/src/main/java/net/william278/husksync/listener/EventListener.java
@@ -127,9 +127,8 @@ public abstract class EventListener {
         // saves run asynchronously and must complete before we close DB/Redis connections.
         plugin.getDataSyncer().awaitPendingSaves();
 
-        // Close outstanding connections
+        // Close the database connection
         plugin.getDatabase().terminate();
-        plugin.getRedisManager().terminate();
     }
 
     /**

--- a/common/src/main/java/net/william278/husksync/listener/EventListener.java
+++ b/common/src/main/java/net/william278/husksync/listener/EventListener.java
@@ -114,13 +114,18 @@ public abstract class EventListener {
      * Handle the plugin disabling
      */
     public void handlePluginDisable() {
-        // Save for all online players.
+        // Save for all online players that haven't been processed by PlayerQuitEvent yet.
         plugin.getOnlineUsers().stream()
                 .filter(user -> !plugin.isLocked(user.getUuid()) && !user.isNpc())
                 .forEach(user -> {
                     plugin.lockPlayer(user.getUuid());
                     plugin.getDataSyncer().saveCurrentUserData(user, DataSnapshot.SaveCause.SERVER_SHUTDOWN);
                 });
+
+        // Wait for in-flight async saves queued by PlayerQuitEvent during shutdown.
+        // Paper kicks players (firing PlayerQuitEvent) before calling onDisable(), so those
+        // saves run asynchronously and must complete before we close DB/Redis connections.
+        plugin.getDataSyncer().awaitPendingSaves();
 
         // Close outstanding connections
         plugin.getDatabase().terminate();

--- a/common/src/main/java/net/william278/husksync/sync/DataSyncer.java
+++ b/common/src/main/java/net/william278/husksync/sync/DataSyncer.java
@@ -32,6 +32,11 @@ import org.jetbrains.annotations.Blocking;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -48,9 +53,11 @@ import java.util.logging.Level;
 public abstract class DataSyncer {
     private static final long BASE_LISTEN_ATTEMPTS = 16;
     private static final long LISTEN_DELAY = 10;
+    private static final long SHUTDOWN_SAVE_TIMEOUT_MS = 5000L;
 
     protected final HuskSync plugin;
     private final long maxListenAttempts;
+    private final Set<CompletableFuture<Void>> pendingSaves = ConcurrentHashMap.newKeySet();
 
     @ApiStatus.Internal
     protected DataSyncer(@NotNull HuskSync plugin) {
@@ -211,6 +218,35 @@ public abstract class DataSyncer {
         };
         task.set(plugin.getRepeatingTask(runnable, LISTEN_DELAY));
         task.get().run();
+    }
+
+    /**
+     * Run a task asynchronously and track it so {@link #awaitPendingSaves} can wait for completion.
+     * Subclasses should use this instead of {@code plugin.runAsync()} for disconnect saves.
+     */
+    protected CompletableFuture<Void> runTrackedAsync(@NotNull Runnable task) {
+        final CompletableFuture<Void> future = CompletableFuture.runAsync(task);
+        pendingSaves.add(future);
+        future.whenComplete((v, t) -> pendingSaves.remove(future));
+        return future;
+    }
+
+    /**
+     * Block until all in-flight disconnect saves complete, up to {@code SHUTDOWN_SAVE_TIMEOUT_MS}.
+     * Called during plugin shutdown before connections are terminated.
+     */
+    public void awaitPendingSaves() {
+        if (pendingSaves.isEmpty()) {
+            return;
+        }
+        try {
+            CompletableFuture.allOf(pendingSaves.toArray(CompletableFuture[]::new))
+                    .get(SHUTDOWN_SAVE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            plugin.log(Level.WARNING, "Shutdown: timed out waiting for in-flight player saves ("
+                    + SHUTDOWN_SAVE_TIMEOUT_MS + "ms); some data may not have been flushed to Redis");
+        } catch (Exception ignored) {
+        }
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/husksync/sync/DataSyncer.java
+++ b/common/src/main/java/net/william278/husksync/sync/DataSyncer.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -221,11 +222,20 @@ public abstract class DataSyncer {
     }
 
     /**
-     * Run a task asynchronously and track it so {@link #awaitPendingSaves} can wait for completion.
-     * Subclasses should use this instead of {@code plugin.runAsync()} for disconnect saves.
+     * Run a task asynchronously via the plugin scheduler and track it so {@link #awaitPendingSaves}
+     * can wait for completion. Uses {@code plugin.runAsync()} instead of the bare ForkJoinPool,
+     * ensuring MorePaperLib's scheduler (with Folia region-context and isPluginDisabled guard) is used.
      */
     protected CompletableFuture<Void> runTrackedAsync(@NotNull Runnable task) {
-        final CompletableFuture<Void> future = CompletableFuture.runAsync(task);
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+        plugin.runAsync(() -> {
+            try {
+                task.run();
+                future.complete(null);
+            } catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        });
         pendingSaves.add(future);
         future.whenComplete((v, t) -> pendingSaves.remove(future));
         return future;
@@ -236,16 +246,17 @@ public abstract class DataSyncer {
      * Called during plugin shutdown before connections are terminated.
      */
     public void awaitPendingSaves() {
-        if (pendingSaves.isEmpty()) {
-            return;
-        }
         try {
             CompletableFuture.allOf(pendingSaves.toArray(CompletableFuture[]::new))
                     .get(SHUTDOWN_SAVE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
             plugin.log(Level.WARNING, "Shutdown: timed out waiting for in-flight player saves ("
                     + SHUTDOWN_SAVE_TIMEOUT_MS + "ms); some data may not have been flushed to Redis");
-        } catch (Exception ignored) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException e) {
+            plugin.log(Level.WARNING, "Shutdown: a player save failed: "
+                    + (e.getCause() != null ? e.getCause().getMessage() : e.getMessage()));
         }
     }
 

--- a/common/src/main/java/net/william278/husksync/sync/DelayDataSyncer.java
+++ b/common/src/main/java/net/william278/husksync/sync/DelayDataSyncer.java
@@ -58,7 +58,7 @@ public class DelayDataSyncer extends DataSyncer {
 
     @Override
     public void syncSaveUserData(@NotNull OnlineUser onlineUser) {
-        plugin.runAsync(() -> {
+        runTrackedAsync(() -> {
             getRedis().setUserServerSwitch(onlineUser);
             saveData(
                     onlineUser, onlineUser.createSnapshot(DataSnapshot.SaveCause.DISCONNECT),

--- a/common/src/main/java/net/william278/husksync/sync/LockstepDataSyncer.java
+++ b/common/src/main/java/net/william278/husksync/sync/LockstepDataSyncer.java
@@ -72,7 +72,7 @@ public class LockstepDataSyncer extends DataSyncer {
 
     @Override
     public void syncSaveUserData(@NotNull OnlineUser onlineUser) {
-        plugin.runAsync(() -> saveData(
+        runTrackedAsync(() -> saveData(
                 onlineUser, onlineUser.createSnapshot(DataSnapshot.SaveCause.DISCONNECT),
                 (user, data) -> {
                     getRedis().setUserData(user, data);

--- a/fabric/src/main/java/net/william278/husksync/FabricHuskSync.java
+++ b/fabric/src/main/java/net/william278/husksync/FabricHuskSync.java
@@ -239,12 +239,16 @@ public class FabricHuskSync implements DedicatedServerModInitializer, HuskSync, 
         // Handle shutdown
         this.disabling = true;
 
-        // Close the event listener / data syncer
-        if (this.dataSyncer != null) {
-            this.dataSyncer.terminate();
-        }
+        // 1. Complete all player saves (including in-flight async saves from disconnect events)
+        //    and close DB/Redis connections. Must run before terminate() clears Redis checkout
+        //    keys, otherwise another server may read a stale LATEST_SNAPSHOT (fix for #654).
         if (this.eventListener != null) {
             this.eventListener.handlePluginDisable();
+        }
+
+        // 2. Clear Redis checkout state after snapshots are correctly persisted
+        if (this.dataSyncer != null) {
+            this.dataSyncer.terminate();
         }
 
         // Cancel tasks, close audiences

--- a/fabric/src/main/java/net/william278/husksync/FabricHuskSync.java
+++ b/fabric/src/main/java/net/william278/husksync/FabricHuskSync.java
@@ -240,7 +240,7 @@ public class FabricHuskSync implements DedicatedServerModInitializer, HuskSync, 
         this.disabling = true;
 
         // 1. Complete all player saves (including in-flight async saves from disconnect events)
-        //    and close DB/Redis connections. Must run before terminate() clears Redis checkout
+        //    and close DB connections. Must run before terminate() clears Redis checkout
         //    keys, otherwise another server may read a stale LATEST_SNAPSHOT (fix for #654).
         if (this.eventListener != null) {
             this.eventListener.handlePluginDisable();
@@ -249,6 +249,11 @@ public class FabricHuskSync implements DedicatedServerModInitializer, HuskSync, 
         // 2. Clear Redis checkout state after snapshots are correctly persisted
         if (this.dataSyncer != null) {
             this.dataSyncer.terminate();
+        }
+
+        // 3. Close Redis after checkout keys are cleared (must be last)
+        if (this.redisManager != null) {
+            this.redisManager.terminate();
         }
 
         // Cancel tasks, close audiences


### PR DESCRIPTION
## Problem

Fixes #654. When a player drops an item on Server A and Server A then restarts, the item appears both on the ground (Server A's world save) and in the player's inventory on Server B — a classic duplication.

## Root Cause

Paper fires `PlayerQuitEvent` (which queues an **async** disconnect save) **before** calling `onDisable()`. The current shutdown sequence has two bugs:

**Bug 1 — async save race (primary cause of #654):**
```
onDisable()
  → dataSyncer.terminate()       ← clears Redis checkout keys immediately
  → eventListener.handlePluginDisable()
      → saves unlocked players (none — all locked by PlayerQuitEvent)
      → database.terminate()     ← closes connections
      → redisManager.terminate() ← closes connections
                                 ← async save task from PlayerQuitEvent now fails silently
                                    LATEST_SNAPSHOT in Redis is never updated (stale)
```

Server B receives the cleared checkout, reads the stale `LATEST_SNAPSHOT` (pre-drop), and restores the item → duplication.

**Bug 2 — Redis closed before checkout keys are cleared:**
`LockstepDataSyncer.terminate()` calls `getRedis().clearUsersCheckedOutOnServer()`, but `redisManager.terminate()` was called inside `handlePluginDisable()` — **before** `dataSyncer.terminate()`. Redis was already closed when checkout keys needed to be cleared, causing them to be left behind silently.

## Fix

1. **`DataSyncer`** — add `runTrackedAsync()` (wraps tasks in a tracked `CompletableFuture`) and `awaitPendingSaves()` (blocks up to 5 s for all in-flight saves to complete).

2. **`LockstepDataSyncer` / `DelayDataSyncer`** — use `runTrackedAsync()` instead of `plugin.runAsync()` so disconnect saves are tracked.

3. **`EventListener.handlePluginDisable()`** — call `awaitPendingSaves()` before closing DB; remove `redisManager.terminate()` (moved to step 5).

4. **`BukkitHuskSync` / `FabricHuskSync` `onDisable()`** — swap execution order: run `handlePluginDisable` (save + await + DB close) **before** `dataSyncer.terminate()` (checkout clear).

5. **`BukkitHuskSync` / `FabricHuskSync` `onDisable()`** — call `redisManager.terminate()` **after** `dataSyncer.terminate()` (with null guard), ensuring Redis stays open until checkout keys are fully cleared.

**Correct shutdown order:**
```
onDisable()
  → handlePluginDisable()
      → save unlocked players
      → awaitPendingSaves()      ← waits for all PlayerQuitEvent async saves
      → database.terminate()     ← DB closes
  → dataSyncer.terminate()       ← clearUsersCheckedOutOnServer() — Redis still open
  → redisManager.terminate()     ← Redis closes last
```

## Test Plan

- [ ] Drop an item, immediately restart the server; confirm the item is **not** in inventory on reconnect
- [ ] Normal server switch: confirm inventory sync still works correctly
- [ ] Server shutdown with no players online: confirm clean shutdown (no timeout warning logged)
- [ ] Both Lockstep and Delay sync modes verified