### PR TITLE
feat: add Paper 26.1.2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - name: 'Checkout for CI 🛎️'
         uses: actions/checkout@v6
-      - name: 'Set up JDK 21 📦'
+      - name: 'Set up JDK 25 📦'
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: 'Build with Gradle 🏗️'
         uses: gradle/gradle-build-action@v3
@@ -57,11 +57,13 @@ jobs:
             paper-1.21.8
             paper-1.21.10
             paper-1.21.11
+            paper-26.1.2
             fabric-1.21.1
             fabric-1.21.4
             fabric-1.21.5
             fabric-1.21.8
           distro-groups: |
+            paper
             paper
             paper
             paper
@@ -79,6 +81,7 @@ jobs:
             Paper 1.21.8
             Paper 1.21.10
             Paper 1.21.11
+            paper 26.1.2
             Fabric 1.21.1
             Fabric 1.21.4
             Fabric 1.21.5
@@ -90,6 +93,7 @@ jobs:
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.1.21.8.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.1.21.10.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.1.21.11.jar
+            target/HuskSync-Bukkit-${{ env.version_name }}+mc.26.1.2.jar
             target/HuskSync-Fabric-${{ env.version_name }}+mc.1.21.1.jar
             target/HuskSync-Fabric-${{ env.version_name }}+mc.1.21.4.jar
             target/HuskSync-Fabric-${{ env.version_name }}+mc.1.21.5.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: 'Checkout for CI 🛎️'
         uses: actions/checkout@v6
-      - name: 'Set up JDK 21 📦'
+      - name: 'Set up JDK 25 📦'
         uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - name: 'Build with Gradle 🏗️'
         uses: gradle/gradle-build-action@v3
@@ -45,11 +45,15 @@ jobs:
             paper-1.21.5
             paper-1.21.8
             paper-1.21.10
+            paper-1.21.11
+            paper-26.1.2
             fabric-1.21.1
             fabric-1.21.4
             fabric-1.21.5
             fabric-1.21.8
           distro-groups: |
+            paper
+            paper
             paper
             paper
             paper
@@ -65,6 +69,8 @@ jobs:
             Paper 1.21.5
             Paper 1.21.8
             Paper 1.21.10
+            Paper 1.21.11
+            Paper 26.1.2
             Fabric 1.21.1
             Fabric 1.21.4
             Fabric 1.21.5
@@ -75,6 +81,8 @@ jobs:
             target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.1.21.5.jar
             target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.1.21.8.jar
             target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.1.21.10.jar
+            target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.1.21.11.jar
+            target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.26.1.2.jar
             target/HuskSync-Fabric-${{ github.event.release.tag_name }}+mc.1.21.1.jar
             target/HuskSync-Fabric-${{ github.event.release.tag_name }}+mc.1.21.4.jar
             target/HuskSync-Fabric-${{ github.event.release.tag_name }}+mc.1.21.5.jar

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,13 @@ subprojects {
 
     // Version-specific configuration
     if (['fabric', 'bukkit'].contains(project.parent?.name)) {
-        compileJava.options.release.set 21
+        def javaVer = project.hasProperty('java_version') ? Integer.parseInt(project.java_version as String) : 21
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(javaVer)
+            }
+        }
+        compileJava.options.release.set javaVer
         version += "+mc.${project.name}"
 
         if (project.parent?.name?.equals('fabric')) {

--- a/bukkit/26.1.2/gradle.properties
+++ b/bukkit/26.1.2/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version_range=>=26.1.2 <=26.1.2
+minecraft_version_numeric=260102
+minecraft_api_version=26.1
+paper_api_version=26.1.2.build.62-stable
+java_version=25

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -16,12 +16,12 @@ dependencies {
     implementation 'net.william278:mapdataapi:2.0'
     implementation 'org.bstats:bstats-bukkit:3.1.0'
     implementation 'net.kyori:adventure-platform-bukkit:4.4.1'
-    implementation 'dev.triumphteam:triumph-gui:3.1.12'
+    implementation 'dev.triumphteam:triumph-gui:3.1.13'
     implementation 'space.arim.morepaperlib:morepaperlib:0.4.4'
-    implementation 'de.tr7zw:item-nbt-api:2.15.5'
+    implementation 'de.tr7zw:item-nbt-api:2.15.7'
 
     compileOnly "io.papermc.paper:paper-api:${paper_api_version}"
-    compileOnly 'com.github.retrooper:packetevents-spigot:2.10.1'
+    compileOnly 'com.github.retrooper:packetevents-spigot:2.12.1'
     compileOnly 'com.github.dmulloy2:ProtocolLib:5.3.0'
     compileOnly 'org.projectlombok:lombok:1.18.42'
     compileOnly 'commons-io:commons-io:2.21.0'

--- a/common/src/main/java/net/william278/husksync/util/DataVersionSupplier.java
+++ b/common/src/main/java/net/william278/husksync/util/DataVersionSupplier.java
@@ -44,6 +44,7 @@ public interface DataVersionSupplier {
     int VERSION1_21_9 = 4554;
     int VERSION1_21_10 = 4556;
     int VERSION1_21_11 = 4671;
+	int VERSION26_1 = 4786;
 
     /**
      * Returns the data version for a Minecraft version
@@ -72,7 +73,8 @@ public interface DataVersionSupplier {
             case "1.21.9" -> VERSION1_21_9;
             case "1.21.10" -> VERSION1_21_10;
             case "1.21.11" -> VERSION1_21_11;
-            default -> VERSION1_21_11; // Latest supported version
+			case "26.1", "26.1.1", "26.1.2" -> VERSION26_1;
+			default -> VERSION26_1; // Latest supported version
         };
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Gradle settings
 org.gradle.jvmargs='-Dfile.encoding=UTF-8'
 org.gradle.daemon=true
-javaVersion=21
+javaVersion=25
 
 # Plugin metadata
 plugin_version=3.8.8

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+}
+
 // Common
 rootProject.name = 'HuskSync'
 include("common")


### PR DESCRIPTION
After two weeks of production testing, everything is running normally, it runs stably on Paper 26.1.2.

Close https://github.com/WiIIiam278/HuskSync/issues/653

Test Jar
https://github.com/CatTeaA/HuskSync/actions/runs/25953637734/artifacts/7030789470