### PR TITLE
Prevent inventory and Ender Chest editor from overwriting concurrent item changes

### DIFF
--- a/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
@@ -65,7 +65,7 @@ public class EnderChestCommand extends ItemsCommand {
                 enderChest.getSlotCount(),
                 (itemsOnClose) -> {
                     if (allowEdit && !enderChest.equals(itemsOnClose)) {
-                        plugin.runAsync(() -> this.updateItems(viewer, itemsOnClose, user));
+                        plugin.runAsync(() -> this.updateItems(viewer, enderChest, itemsOnClose, user));
                     }
                 }
         );
@@ -73,11 +73,23 @@ public class EnderChestCommand extends ItemsCommand {
 
     // Creates a new snapshot with the updated enderChest
     @SuppressWarnings("DuplicatedCode")
-    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items items, @NotNull User holder) {
+    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items openedItems, @NotNull Data.Items.Items items, @NotNull User holder) {
         final Optional<DataSnapshot.Packed> latestData = plugin.getDatabase().getLatestSnapshot(holder);
         if (latestData.isEmpty()) {
             plugin.getLocales().getLocale("error_no_data_to_display")
                     .ifPresent(viewer::sendMessage);
+            return;
+        }
+
+        final Optional<Data.Items.EnderChest> latestEnderChest = latestData.get().unpack(plugin).getEnderChest();
+        if (latestEnderChest.isEmpty()) {
+            plugin.getLocales().getLocale("error_no_data_to_display")
+                    .ifPresent(viewer::sendMessage);
+            return;
+        }
+
+        if (!latestEnderChest.get().equals(openedItems)) {
+            plugin.getLocales().getLocale("error_ender_chest_changed").ifPresent(viewer::sendMessage);
             return;
         }
 
@@ -97,5 +109,4 @@ public class EnderChestCommand extends ItemsCommand {
             redis.sendUserDataUpdate(user, data);
         });
     }
-
 }

--- a/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
@@ -65,7 +65,7 @@ public class InventoryCommand extends ItemsCommand {
                 inventory.getSlotCount(),
                 (itemsOnClose) -> {
                     if (allowEdit && !inventory.equals(itemsOnClose)) {
-                        plugin.runAsync(() -> this.updateItems(viewer, itemsOnClose, user));
+                        plugin.runAsync(() -> this.updateItems(viewer, inventory, itemsOnClose, user));
                     }
                 }
         );
@@ -73,11 +73,24 @@ public class InventoryCommand extends ItemsCommand {
 
     // Creates a new snapshot with the updated inventory
     @SuppressWarnings("DuplicatedCode")
-    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items items, @NotNull User holder) {
+    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items openedItems,
+                             @NotNull Data.Items.Items items, @NotNull User holder) {
         final Optional<DataSnapshot.Packed> latestData = plugin.getDatabase().getLatestSnapshot(holder);
         if (latestData.isEmpty()) {
             plugin.getLocales().getLocale("error_no_data_to_display")
                     .ifPresent(viewer::sendMessage);
+            return;
+        }
+
+        final Optional<Data.Items.Inventory> latestInventory = latestData.get().unpack(plugin).getInventory();
+        if (latestInventory.isEmpty()) {
+            plugin.getLocales().getLocale("error_no_data_to_display")
+                    .ifPresent(viewer::sendMessage);
+            return;
+        }
+
+        if (!latestInventory.get().equals(openedItems)) {
+            plugin.getLocales().getLocale("error_inventory_changed").ifPresent(viewer::sendMessage);
             return;
         }
 
@@ -97,5 +110,4 @@ public class InventoryCommand extends ItemsCommand {
             redis.sendUserDataUpdate(user, data);
         });
     }
-
 }

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -65,6 +65,8 @@ locales:
   error_in_game_command_only: 'Error: That command can only be used in-game.'
   error_no_data_to_display: '[Error:](#ff3300) [Could not find any user data to display.](#ff7e5e)'
   error_invalid_version_uuid: '[Error:](#ff3300) [Could not find any user data for that version UUID.](#ff7e5e)'
+  error_inventory_changed: '[Error:](#ff3300) [This player''s inventory changed while you were editing it. Reopen the inventory and try again.](#ff7e5e)'
+  error_ender_chest_changed: '[Error:](#ff3300) [This player''s Ender Chest changed while you were editing it. Reopen the Ender Chest and try again.](#ff7e5e)'
   husksync_command_description: 'Manage the HuskSync plugin'
   userdata_command_description: 'View, manage & restore player userdata'
   inventory_command_description: 'View & edit a player''s inventory'


### PR DESCRIPTION
This PR fixes a race condition in the /inventory and /enderchest editors where a player’s item changes could be overwritten if their data changed while an administrator had the editor GUI open.
Previously, the editor would save the GUI contents when closed as long as the administrator made changes. If the target player picked up, moved, dropped, or otherwise changed items while the GUI was open, those newer changes could be overwritten by the older editor view when the GUI closed.