### PR TITLE
Prevent item editor saves from overwriting concurrent inventory changes

### DIFF
--- a/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
@@ -65,7 +65,7 @@ public class EnderChestCommand extends ItemsCommand {
                 enderChest.getSlotCount(),
                 (itemsOnClose) -> {
                     if (allowEdit && !enderChest.equals(itemsOnClose)) {
-                        plugin.runAsync(() -> this.updateItems(viewer, itemsOnClose, user));
+                        plugin.runAsync(() -> this.updateItems(viewer, enderChest, itemsOnClose, user));
                     }
                 }
         );
@@ -73,11 +73,23 @@ public class EnderChestCommand extends ItemsCommand {
 
     // Creates a new snapshot with the updated enderChest
     @SuppressWarnings("DuplicatedCode")
-    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items items, @NotNull User holder) {
+    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items openedItems, @NotNull Data.Items.Items items, @NotNull User holder) {
         final Optional<DataSnapshot.Packed> latestData = plugin.getDatabase().getLatestSnapshot(holder);
         if (latestData.isEmpty()) {
             plugin.getLocales().getLocale("error_no_data_to_display")
                     .ifPresent(viewer::sendMessage);
+            return;
+        }
+
+        final Optional<Data.Items.EnderChest> latestEnderChest = latestData.get().unpack(plugin).getEnderChest();
+        if (latestEnderChest.isEmpty()) {
+            plugin.getLocales().getLocale("error_no_data_to_display")
+                    .ifPresent(viewer::sendMessage);
+            return;
+        }
+
+        if (!latestEnderChest.get().equals(openedItems)) {
+            plugin.getLocales().getLocale("error_ender_chest_changed").ifPresent(viewer::sendMessage);
             return;
         }
 
@@ -97,5 +109,4 @@ public class EnderChestCommand extends ItemsCommand {
             redis.sendUserDataUpdate(user, data);
         });
     }
-
 }

--- a/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
@@ -30,8 +30,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 public class EnderChestCommand extends ItemsCommand {
 
@@ -64,8 +67,10 @@ public class EnderChestCommand extends ItemsCommand {
                 allowEdit,
                 enderChest.getSlotCount(),
                 (itemsOnClose) -> {
-                    if (allowEdit && !enderChest.equals(itemsOnClose)) {
-                        plugin.runAsync(() -> this.updateItems(viewer, enderChest, itemsOnClose, user));
+                    if (allowEdit && !itemsEqual(enderChest, itemsOnClose)) {
+                        plugin.runAsync(() -> this.updateItems(
+                                viewer, enderChest, itemsOnClose, user
+                        ));
                     }
                 }
         );
@@ -73,7 +78,8 @@ public class EnderChestCommand extends ItemsCommand {
 
     // Creates a new snapshot with the updated enderChest
     @SuppressWarnings("DuplicatedCode")
-    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items openedItems, @NotNull Data.Items.Items items, @NotNull User holder) {
+    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items openedItems,
+                             @NotNull Data.Items.Items items, @NotNull User holder) {
         final Optional<DataSnapshot.Packed> latestData = plugin.getDatabase().getLatestSnapshot(holder);
         if (latestData.isEmpty()) {
             plugin.getLocales().getLocale("error_no_data_to_display")
@@ -81,32 +87,73 @@ public class EnderChestCommand extends ItemsCommand {
             return;
         }
 
-        final Optional<Data.Items.EnderChest> latestEnderChest = latestData.get().unpack(plugin).getEnderChest();
-        if (latestEnderChest.isEmpty()) {
-            plugin.getLocales().getLocale("error_no_data_to_display")
-                    .ifPresent(viewer::sendMessage);
-            return;
-        }
+        plugin.getRedisManager().getOnlineUserData(UUID.randomUUID(), holder, saveCause).thenAccept(currentData -> {
+            final Optional<Data.Items.EnderChest> currentEnderChest = currentData
+                    .or(() -> latestData)
+                    .flatMap(snapshot -> snapshot.unpack(plugin).getEnderChest());
 
-        if (!latestEnderChest.get().equals(openedItems)) {
-            plugin.getLocales().getLocale("error_ender_chest_changed").ifPresent(viewer::sendMessage);
-            return;
-        }
+            if (currentEnderChest.isEmpty()) {
+                plugin.getLocales().getLocale("error_no_data_to_display")
+                        .ifPresent(viewer::sendMessage);
+                return;
+            }
 
-        // Create and pack the snapshot with the updated enderChest
-        final DataSnapshot.Packed snapshot = latestData.get().copy();
-        boolean pin = plugin.getSettings().getSynchronization().doAutoPin(saveCause);
-        snapshot.edit(plugin, (data) -> {
-            data.getEnderChest().ifPresent(enderChest -> enderChest.setContents(items));
-            data.setSaveCause(saveCause);
-            data.setPinned(pin);
+            if (itemsEqual(currentEnderChest.get(), items)) {
+                return;
+            }
+
+            if (!itemsEqual(currentEnderChest.get(), openedItems)) {
+                plugin.getLocales().getLocale("error_ender_chest_changed").ifPresent(viewer::sendMessage);
+                return;
+            }
+
+            // Create and pack the snapshot with the updated enderChest
+            final DataSnapshot.Packed snapshot = latestData.get().copy();
+            boolean pin = plugin.getSettings().getSynchronization().doAutoPin(saveCause);
+
+            snapshot.edit(plugin, (data) -> {
+                data.getEnderChest().ifPresent(enderChest -> enderChest.setContents(items));
+                data.setSaveCause(saveCause);
+                data.setPinned(pin);
+            });
+
+            // Save data
+            final RedisManager redis = plugin.getRedisManager();
+            plugin.getDataSyncer().saveData(holder, snapshot, (user, data) -> {
+                redis.getUserData(user).ifPresent(d -> redis.setUserData(user, snapshot));
+                redis.sendUserDataUpdate(user, data);
+            });
         });
+    }
 
-        // Save data
-        final RedisManager redis = plugin.getRedisManager();
-        plugin.getDataSyncer().saveData(holder, snapshot, (user, data) -> {
-            redis.getUserData(user).ifPresent(d -> redis.setUserData(user, snapshot));
-            redis.sendUserDataUpdate(user, data);
-        });
+    private boolean itemsEqual(@NotNull Data.Items first, @NotNull Data.Items second) {
+        final Data.Items.Stack[] firstStacks = first.getStack();
+        final Data.Items.Stack[] secondStacks = second.getStack();
+        final int slotCount = first.getSlotCount();
+
+        for (int slot = 0; slot < slotCount; slot++) {
+            if (!stackEqual(getStack(firstStacks, slot), getStack(secondStacks, slot))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Data.Items.Stack getStack(@NotNull Data.Items.Stack[] stacks, int slot) {
+        return slot < stacks.length ? stacks[slot] : null;
+    }
+
+    private boolean stackEqual(Data.Items.Stack first, Data.Items.Stack second) {
+        if (first == second) {
+            return true;
+        }
+        if (first == null || second == null) {
+            return false;
+        }
+        return first.amount() == second.amount()
+                && first.material().equals(second.material())
+                && Objects.equals(first.name(), second.name())
+                && Objects.equals(first.lore(), second.lore())
+                && new HashSet<>(first.enchantments()).equals(new HashSet<>(second.enchantments()));
     }
 }

--- a/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
@@ -27,6 +27,7 @@ import net.william278.husksync.redis.RedisManager;
 import net.william278.husksync.user.OnlineUser;
 import net.william278.husksync.user.User;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
@@ -60,6 +61,7 @@ public class EnderChestCommand extends ItemsCommand {
 
         // Show GUI
         final Data.Items.EnderChest enderChest = optionalEnderChest.get();
+        final Optional<Data.Items.Inventory> openedInventory = snapshot.getInventory();
         viewer.showGui(
                 enderChest,
                 plugin.getLocales().getLocale("ender_chest_viewer_menu_title", user.getName())
@@ -69,7 +71,7 @@ public class EnderChestCommand extends ItemsCommand {
                 (itemsOnClose) -> {
                     if (allowEdit && !itemsEqual(enderChest, itemsOnClose)) {
                         plugin.runAsync(() -> this.updateItems(
-                                viewer, enderChest, itemsOnClose, user
+                                viewer, enderChest, openedInventory.orElse(null), itemsOnClose, user
                         ));
                     }
                 }
@@ -79,6 +81,7 @@ public class EnderChestCommand extends ItemsCommand {
     // Creates a new snapshot with the updated enderChest
     @SuppressWarnings("DuplicatedCode")
     private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items openedItems,
+                             @Nullable Data.Items.Inventory openedInventory,
                              @NotNull Data.Items.Items items, @NotNull User holder) {
         final Optional<DataSnapshot.Packed> latestData = plugin.getDatabase().getLatestSnapshot(holder);
         if (latestData.isEmpty()) {
@@ -88,10 +91,12 @@ public class EnderChestCommand extends ItemsCommand {
         }
 
         plugin.getRedisManager().getOnlineUserData(UUID.randomUUID(), holder, saveCause).thenAccept(currentData -> {
-            final Optional<Data.Items.EnderChest> currentEnderChest = currentData
+            final DataSnapshot.Unpacked currentSnapshot = currentData
                     .or(() -> latestData)
-                    .flatMap(snapshot -> snapshot.unpack(plugin).getEnderChest());
+                    .map(snapshot -> snapshot.unpack(plugin))
+                    .orElseThrow();
 
+            final Optional<Data.Items.EnderChest> currentEnderChest = currentSnapshot.getEnderChest();
             if (currentEnderChest.isEmpty()) {
                 plugin.getLocales().getLocale("error_no_data_to_display")
                         .ifPresent(viewer::sendMessage);
@@ -103,6 +108,13 @@ public class EnderChestCommand extends ItemsCommand {
             }
 
             if (!itemsEqual(currentEnderChest.get(), openedItems)) {
+                plugin.getLocales().getLocale("error_ender_chest_changed").ifPresent(viewer::sendMessage);
+                return;
+            }
+
+            final Optional<Data.Items.Inventory> currentInventory = currentSnapshot.getInventory();
+            if (openedInventory != null && currentInventory.isPresent()
+                    && !itemsEqual(currentInventory.get(), openedInventory)) {
                 plugin.getLocales().getLocale("error_ender_chest_changed").ifPresent(viewer::sendMessage);
                 return;
             }

--- a/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/EnderChestCommand.java
@@ -120,7 +120,7 @@ public class EnderChestCommand extends ItemsCommand {
             }
 
             // Create and pack the snapshot with the updated enderChest
-            final DataSnapshot.Packed snapshot = latestData.get().copy();
+            final DataSnapshot.Packed snapshot = currentData.or(() -> latestData).orElseThrow().copy();
             boolean pin = plugin.getSettings().getSynchronization().doAutoPin(saveCause);
 
             snapshot.edit(plugin, (data) -> {

--- a/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
@@ -30,8 +30,11 @@ import org.jetbrains.annotations.NotNull;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 public class InventoryCommand extends ItemsCommand {
 
@@ -64,8 +67,10 @@ public class InventoryCommand extends ItemsCommand {
                 allowEdit,
                 inventory.getSlotCount(),
                 (itemsOnClose) -> {
-                    if (allowEdit && !inventory.equals(itemsOnClose)) {
-                        plugin.runAsync(() -> this.updateItems(viewer, inventory, itemsOnClose, user));
+                    if (allowEdit && !itemsEqual(inventory, itemsOnClose)) {
+                        plugin.runAsync(() -> this.updateItems(
+                                viewer, inventory, itemsOnClose, user
+                        ));
                     }
                 }
         );
@@ -82,32 +87,72 @@ public class InventoryCommand extends ItemsCommand {
             return;
         }
 
-        final Optional<Data.Items.Inventory> latestInventory = latestData.get().unpack(plugin).getInventory();
-        if (latestInventory.isEmpty()) {
-            plugin.getLocales().getLocale("error_no_data_to_display")
-                    .ifPresent(viewer::sendMessage);
-            return;
-        }
+        plugin.getRedisManager().getOnlineUserData(UUID.randomUUID(), holder, saveCause).thenAccept(currentData -> {
+            final Optional<Data.Items.Inventory> currentInventory = currentData
+                    .or(() -> latestData)
+                    .flatMap(snapshot -> snapshot.unpack(plugin).getInventory());
 
-        if (!latestInventory.get().equals(openedItems)) {
-            plugin.getLocales().getLocale("error_inventory_changed").ifPresent(viewer::sendMessage);
-            return;
-        }
+            if (currentInventory.isEmpty()) {
+                plugin.getLocales().getLocale("error_no_data_to_display")
+                        .ifPresent(viewer::sendMessage);
+                return;
+            }
 
-        // Create and pack the snapshot with the updated inventory
-        final DataSnapshot.Packed snapshot = latestData.get().copy();
-        boolean pin = plugin.getSettings().getSynchronization().doAutoPin(saveCause);
-        snapshot.edit(plugin, (data) -> {
-            data.getInventory().ifPresent(inventory -> inventory.setContents(items));
-            data.setSaveCause(saveCause);
-            data.setPinned(pin);
+            if (itemsEqual(currentInventory.get(), items)) {
+                return;
+            }
+
+            if (!itemsEqual(currentInventory.get(), openedItems)) {
+                plugin.getLocales().getLocale("error_inventory_changed").ifPresent(viewer::sendMessage);
+                return;
+            }
+
+            // Create and pack the snapshot with the updated inventory
+            final DataSnapshot.Packed snapshot = latestData.get().copy();
+            boolean pin = plugin.getSettings().getSynchronization().doAutoPin(saveCause);
+            snapshot.edit(plugin, (data) -> {
+                data.getInventory().ifPresent(inventory -> inventory.setContents(items));
+                data.setSaveCause(saveCause);
+                data.setPinned(pin);
+            });
+
+            // Save data
+            final RedisManager redis = plugin.getRedisManager();
+            plugin.getDataSyncer().saveData(holder, snapshot, (user, data) -> {
+                redis.getUserData(user).ifPresent(d -> redis.setUserData(user, snapshot));
+                redis.sendUserDataUpdate(user, data);
+            });
         });
+    }
 
-        // Save data
-        final RedisManager redis = plugin.getRedisManager();
-        plugin.getDataSyncer().saveData(holder, snapshot, (user, data) -> {
-            redis.getUserData(user).ifPresent(d -> redis.setUserData(user, snapshot));
-            redis.sendUserDataUpdate(user, data);
-        });
+    private boolean itemsEqual(@NotNull Data.Items first, @NotNull Data.Items second) {
+        final Data.Items.Stack[] firstStacks = first.getStack();
+        final Data.Items.Stack[] secondStacks = second.getStack();
+        final int slotCount = first.getSlotCount();
+
+        for (int slot = 0; slot < slotCount; slot++) {
+            if (!stackEqual(getStack(firstStacks, slot), getStack(secondStacks, slot))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Data.Items.Stack getStack(@NotNull Data.Items.Stack[] stacks, int slot) {
+        return slot < stacks.length ? stacks[slot] : null;
+    }
+
+    private boolean stackEqual(Data.Items.Stack first, Data.Items.Stack second) {
+        if (first == second) {
+            return true;
+        }
+        if (first == null || second == null) {
+            return false;
+        }
+        return first.amount() == second.amount()
+                && first.material().equals(second.material())
+                && Objects.equals(first.name(), second.name())
+                && Objects.equals(first.lore(), second.lore())
+                && new HashSet<>(first.enchantments()).equals(new HashSet<>(second.enchantments()));
     }
 }

--- a/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
@@ -27,6 +27,7 @@ import net.william278.husksync.redis.RedisManager;
 import net.william278.husksync.user.OnlineUser;
 import net.william278.husksync.user.User;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
@@ -60,6 +61,7 @@ public class InventoryCommand extends ItemsCommand {
 
         // Show GUI
         final Data.Items.Inventory inventory = optionalInventory.get();
+        final Optional<Data.Items.EnderChest> openedEnderChest = snapshot.getEnderChest();
         viewer.showGui(
                 inventory,
                 plugin.getLocales().getLocale("inventory_viewer_menu_title", user.getName())
@@ -69,7 +71,7 @@ public class InventoryCommand extends ItemsCommand {
                 (itemsOnClose) -> {
                     if (allowEdit && !itemsEqual(inventory, itemsOnClose)) {
                         plugin.runAsync(() -> this.updateItems(
-                                viewer, inventory, itemsOnClose, user
+                                viewer, inventory, openedEnderChest.orElse(null), itemsOnClose, user
                         ));
                     }
                 }
@@ -79,6 +81,7 @@ public class InventoryCommand extends ItemsCommand {
     // Creates a new snapshot with the updated inventory
     @SuppressWarnings("DuplicatedCode")
     private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items openedItems,
+                             @Nullable Data.Items.EnderChest openedEnderChest,
                              @NotNull Data.Items.Items items, @NotNull User holder) {
         final Optional<DataSnapshot.Packed> latestData = plugin.getDatabase().getLatestSnapshot(holder);
         if (latestData.isEmpty()) {
@@ -88,10 +91,12 @@ public class InventoryCommand extends ItemsCommand {
         }
 
         plugin.getRedisManager().getOnlineUserData(UUID.randomUUID(), holder, saveCause).thenAccept(currentData -> {
-            final Optional<Data.Items.Inventory> currentInventory = currentData
+            final DataSnapshot.Unpacked currentSnapshot = currentData
                     .or(() -> latestData)
-                    .flatMap(snapshot -> snapshot.unpack(plugin).getInventory());
+                    .map(snapshot -> snapshot.unpack(plugin))
+                    .orElseThrow();
 
+            final Optional<Data.Items.Inventory> currentInventory = currentSnapshot.getInventory();
             if (currentInventory.isEmpty()) {
                 plugin.getLocales().getLocale("error_no_data_to_display")
                         .ifPresent(viewer::sendMessage);
@@ -103,6 +108,13 @@ public class InventoryCommand extends ItemsCommand {
             }
 
             if (!itemsEqual(currentInventory.get(), openedItems)) {
+                plugin.getLocales().getLocale("error_inventory_changed").ifPresent(viewer::sendMessage);
+                return;
+            }
+
+            final Optional<Data.Items.EnderChest> currentEnderChest = currentSnapshot.getEnderChest();
+            if (openedEnderChest != null && currentEnderChest.isPresent()
+                    && !itemsEqual(currentEnderChest.get(), openedEnderChest)) {
                 plugin.getLocales().getLocale("error_inventory_changed").ifPresent(viewer::sendMessage);
                 return;
             }

--- a/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
@@ -65,7 +65,7 @@ public class InventoryCommand extends ItemsCommand {
                 inventory.getSlotCount(),
                 (itemsOnClose) -> {
                     if (allowEdit && !inventory.equals(itemsOnClose)) {
-                        plugin.runAsync(() -> this.updateItems(viewer, itemsOnClose, user));
+                        plugin.runAsync(() -> this.updateItems(viewer, inventory, itemsOnClose, user));
                     }
                 }
         );
@@ -73,11 +73,24 @@ public class InventoryCommand extends ItemsCommand {
 
     // Creates a new snapshot with the updated inventory
     @SuppressWarnings("DuplicatedCode")
-    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items items, @NotNull User holder) {
+    private void updateItems(@NotNull OnlineUser viewer, @NotNull Data.Items.Items openedItems,
+                             @NotNull Data.Items.Items items, @NotNull User holder) {
         final Optional<DataSnapshot.Packed> latestData = plugin.getDatabase().getLatestSnapshot(holder);
         if (latestData.isEmpty()) {
             plugin.getLocales().getLocale("error_no_data_to_display")
                     .ifPresent(viewer::sendMessage);
+            return;
+        }
+
+        final Optional<Data.Items.Inventory> latestInventory = latestData.get().unpack(plugin).getInventory();
+        if (latestInventory.isEmpty()) {
+            plugin.getLocales().getLocale("error_no_data_to_display")
+                    .ifPresent(viewer::sendMessage);
+            return;
+        }
+
+        if (!latestInventory.get().equals(openedItems)) {
+            plugin.getLocales().getLocale("error_inventory_changed").ifPresent(viewer::sendMessage);
             return;
         }
 
@@ -97,5 +110,4 @@ public class InventoryCommand extends ItemsCommand {
             redis.sendUserDataUpdate(user, data);
         });
     }
-
 }

--- a/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
+++ b/common/src/main/java/net/william278/husksync/command/InventoryCommand.java
@@ -120,7 +120,7 @@ public class InventoryCommand extends ItemsCommand {
             }
 
             // Create and pack the snapshot with the updated inventory
-            final DataSnapshot.Packed snapshot = latestData.get().copy();
+            final DataSnapshot.Packed snapshot = currentData.or(() -> latestData).orElseThrow().copy();
             boolean pin = plugin.getSettings().getSynchronization().doAutoPin(saveCause);
             snapshot.edit(plugin, (data) -> {
                 data.getInventory().ifPresent(inventory -> inventory.setContents(items));

--- a/common/src/main/resources/locales/en-gb.yml
+++ b/common/src/main/resources/locales/en-gb.yml
@@ -65,6 +65,8 @@ locales:
   error_in_game_command_only: 'Error: That command can only be used in-game.'
   error_no_data_to_display: '[Error:](#ff3300) [Could not find any user data to display.](#ff7e5e)'
   error_invalid_version_uuid: '[Error:](#ff3300) [Could not find any user data for that version UUID.](#ff7e5e)'
+  error_inventory_changed: '[Error:](#ff3300) [This player''s inventory changed while you were editing it. Reopen the inventory and try again.](#ff7e5e)'
+  error_ender_chest_changed: '[Error:](#ff3300) [This player''s Ender Chest changed while you were editing it. Reopen the Ender Chest and try again.](#ff7e5e)'
   husksync_command_description: 'Manage the HuskSync plugin'
   userdata_command_description: 'View, manage & restore player userdata'
   inventory_command_description: 'View & edit a player''s inventory'


### PR DESCRIPTION
This PR improves the /inventory and /enderchest editors to prevent stale GUI data from being saved over newer player item changes.
Previously, closing an editor could incorrectly trigger a save even when no real changes were made, or overwrite item changes made by the target player while the GUI was open.

**Changes**
- Adds safer item comparison for inventory and Ender Chest editors.
- Compares only logical item slots, avoiding false changes from differing backing array sizes.
- Detects current player item data cross-server before saving.
- Cancels the save if the player’s items changed while the editor was open.
- Skips saving if the current items already match the edited contents.
- Adds locale messages for edit conflict errors.

**Result**
This prevents unnecessary saves and reduces the risk of item loss from stale inventory or Ender Chest editor data.