### PR TITLE
Remove ambient filter when converting potion effects

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
@@ -236,8 +236,7 @@ public abstract class BukkitData implements Data {
 
         @NotNull
         public static BukkitData.PotionEffects from(@NotNull Collection<PotionEffect> sei) {
-            return new BukkitData.PotionEffects(Lists.newArrayList(sei.stream().filter(e -> !e.isAmbient()).toList()));
-
+            return new BukkitData.PotionEffects(Lists.newArrayList(sei));
         }
 
         @NotNull


### PR DESCRIPTION
Removed the ambient effect filter in PotionEffects#from to prevent custom (non-vanilla) potion effects from being lost, during server switches.