### PR TITLE
replace cadixdev.licenser plugin with neoforged fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             Paper 1.21.8
             Paper 1.21.10
             Paper 1.21.11
-            paper 26.1.2
+            Paper 26.1.2
             Fabric 1.21.1
             Fabric 1.21.4
             Fabric 1.21.5

--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ subprojects {
     } else {
         name += "-${project.name.capitalize()}"
     }
-    archivesBaseName = name
+    base.archivesName = name
 
     // Version-specific configuration
     if (['fabric', 'bukkit'].contains(project.parent?.name)) {

--- a/build.gradle
+++ b/build.gradle
@@ -133,7 +133,7 @@ subprojects {
 
     // Version-specific configuration
     if (['fabric', 'bukkit'].contains(project.parent?.name)) {
-        def javaVer = project.hasProperty('java_version') ? Integer.parseInt(project.java_version as String) : 25
+        def javaVer = project.hasProperty('java_version') ? Integer.parseInt(project.java_version as String) : 21
         java {
             toolchain {
                 languageVersion = JavaLanguageVersion.of(javaVer)

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'com.gradleup.shadow' version '9.2.2'
-    id 'net.neoforged.licenser' version '0.7.0' apply false
+    id 'net.neoforged.licenser' version '0.7.5' apply false
     id 'dev.architectury.loom' version '1.9-SNAPSHOT' apply false
     id 'gg.essential.multi-version.root' apply false
     id 'org.ajoberstar.grgit' version '5.3.2'
@@ -65,7 +65,7 @@ allprojects {
     }
     
     apply plugin: 'com.gradleup.shadow'
-    apply plugin: 'org.neoforged.licenser'
+    apply plugin: 'net.neoforged.licenser'
     apply plugin: 'java'
 
     compileJava.options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'com.gradleup.shadow' version '9.2.2'
-    id 'org.neoforged.licenser' version '0.7.0' apply false
+    id 'net.neoforged.licenser' version '0.7.0' apply false
     id 'dev.architectury.loom' version '1.9-SNAPSHOT' apply false
     id 'gg.essential.multi-version.root' apply false
     id 'org.ajoberstar.grgit' version '5.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 plugins {
     id 'com.gradleup.shadow' version '9.2.2'
-    id 'org.cadixdev.licenser' version '0.6.1' apply false
+    id 'org.neoforged.licenser' version '0.7.0' apply false
     id 'dev.architectury.loom' version '1.9-SNAPSHOT' apply false
     id 'gg.essential.multi-version.root' apply false
     id 'org.ajoberstar.grgit' version '5.3.2'
@@ -65,7 +65,7 @@ allprojects {
     }
     
     apply plugin: 'com.gradleup.shadow'
-    apply plugin: 'org.cadixdev.licenser'
+    apply plugin: 'org.neoforged.licenser'
     apply plugin: 'java'
 
     compileJava.options.encoding = 'UTF-8'

--- a/bukkit/1.21.1/gradle.properties
+++ b/bukkit/1.21.1/gradle.properties
@@ -2,3 +2,4 @@ minecraft_version_range=1.21.1
 minecraft_version_numeric=12101
 minecraft_api_version=1.21
 paper_api_version=1.21.1-R0.1-SNAPSHOT
+java_version=21

--- a/bukkit/1.21.10/gradle.properties
+++ b/bukkit/1.21.10/gradle.properties
@@ -2,3 +2,4 @@ minecraft_version_range=>=1.21.9 <=1.21.10
 minecraft_version_numeric=12110
 minecraft_api_version=1.21
 paper_api_version=1.21.10-R0.1-SNAPSHOT
+java_version=21

--- a/bukkit/1.21.11/gradle.properties
+++ b/bukkit/1.21.11/gradle.properties
@@ -2,3 +2,4 @@ minecraft_version_range=>=1.21.11 <=1.21.11
 minecraft_version_numeric=12111
 minecraft_api_version=1.21
 paper_api_version=1.21.11-R0.1-SNAPSHOT
+java_version=21

--- a/bukkit/1.21.4/gradle.properties
+++ b/bukkit/1.21.4/gradle.properties
@@ -2,3 +2,4 @@ minecraft_version_range=1.21.4
 minecraft_version_numeric=12104
 minecraft_api_version=1.21
 paper_api_version=1.21.4-R0.1-SNAPSHOT
+java_version=21

--- a/bukkit/1.21.5/gradle.properties
+++ b/bukkit/1.21.5/gradle.properties
@@ -2,3 +2,4 @@ minecraft_version_range=1.21.5
 minecraft_version_numeric=12105
 minecraft_api_version=1.21
 paper_api_version=1.21.5-R0.1-SNAPSHOT
+java_version=21

--- a/bukkit/1.21.8/gradle.properties
+++ b/bukkit/1.21.8/gradle.properties
@@ -2,3 +2,4 @@ minecraft_version_range=>=1.21.7 <=1.21.8
 minecraft_version_numeric=12108
 minecraft_api_version=1.21
 paper_api_version=1.21.8-R0.1-SNAPSHOT
+java_version=21

--- a/fabric/1.21.1/gradle.properties
+++ b/fabric/1.21.1/gradle.properties
@@ -7,3 +7,4 @@ fabric_api_version=0.107.0+1.21.1
 fabric_permissions_api_version=0.3.1
 fabric_adventure_platform_version=5.14.2
 fabric_sgui_version=1.6.0+1.21
+java_version=21

--- a/fabric/1.21.4/gradle.properties
+++ b/fabric/1.21.4/gradle.properties
@@ -7,3 +7,4 @@ fabric_api_version=0.116.1+1.21.4
 fabric_permissions_api_version=0.3.3
 fabric_adventure_platform_version=6.3.0
 fabric_sgui_version=1.8.2+1.21.4
+java_version=21

--- a/fabric/1.21.5/gradle.properties
+++ b/fabric/1.21.5/gradle.properties
@@ -7,3 +7,4 @@ fabric_api_version=0.122.0+1.21.5
 fabric_permissions_api_version=0.3.3
 fabric_adventure_platform_version=6.4.0
 fabric_sgui_version=1.9.0+1.21.5
+java_version=21

--- a/fabric/1.21.8/gradle.properties
+++ b/fabric/1.21.8/gradle.properties
@@ -7,3 +7,4 @@ fabric_api_version=0.131.0+1.21.8
 fabric_permissions_api_version=0.4.1
 fabric_adventure_platform_version=6.6.0
 fabric_sgui_version=1.10.0+1.21.6
+java_version=21

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -10,6 +10,8 @@ repositories {
     maven { url 'https://maven.nucleoid.xyz' }
 }
 
+def commonProject = rootProject.project(":common")
+
 dependencies {
     modImplementation include("net.kyori:adventure-platform-fabric:${fabric_adventure_platform_version}")
     modImplementation include("me.lucko:fabric-permissions-api:${fabric_permissions_api_version}")
@@ -39,7 +41,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok:1.18.42'
 
     implementation include(project(path: ":common"))
-    project(":common").configurations.api.dependencies.each { dependency ->
+    commonProject.configurations.api.dependencies.each { dependency ->
         include(dependency)
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@ pluginManagement {
         maven { url 'https://maven.fabricmc.net/' }
         maven { url 'https://maven.architectury.dev/' }
         maven { url 'https://maven.minecraftforge.net' }
+        maven { url 'https://maven.neoforged.net/releases' }
         maven { url 'https://repo.essential.gg/public' }
     }
 


### PR DESCRIPTION
As per the discussion in https://github.com/CadixDev/licenser/issues/45, NeoForge have a fork to address the StackOverflow caused by `org.cadixdev.licenser` in Gradle 9