### PR TITLE
feat: add basic Paper 26.2 support (#664)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,14 @@ jobs:
           version: ${{ env.version_name }}
           changelog: ${{ github.event.head_commit.message }}
           distro-names: |
+            paper-26.2
             paper-26.1.2
           distro-groups: |
             paper
+            paper
           distro-descriptions: |
+            Paper 26.2
             Paper 26.1.2
           files: |
+            target/HuskSync-Bukkit-${{ env.version_name }}+mc.26.2.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.26.1.2.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,14 @@ jobs:
           version: ${{ github.event.release.tag_name }}
           changelog: ${{ github.event.release.body }}
           distro-names: |
+            paper-26.2
             paper-26.1.2
           distro-groups: |
             paper
+            paper
           distro-descriptions: |
+            Paper 26.2
             Paper 26.1.2
           files: |
+            target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.26.2.jar
             target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.26.1.2.jar

--- a/bukkit/26.2/gradle.properties
+++ b/bukkit/26.2/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version_range=>=26.2 <=26.2
+minecraft_version_numeric=260200
+minecraft_api_version=26.2
+paper_api_version=26.2.build.24-alpha
+java_version=25

--- a/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
+++ b/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
@@ -149,8 +149,7 @@ public class BukkitHuskSync extends JavaPlugin implements HuskSync, BukkitTask.S
 
         // Preload NBT-API
         if (!NBT.preloadApi()) {
-            log(Level.SEVERE, "Failed to load NBT API. HuskSync will not be initialized!");
-            return;
+            log(Level.WARNING, "Failed to load NBT API (unrecognized server version). NBT features may not work correctly!");
         }
 
         // Register commands

--- a/common/src/main/java/net/william278/husksync/listener/EventListener.java
+++ b/common/src/main/java/net/william278/husksync/listener/EventListener.java
@@ -71,6 +71,9 @@ public abstract class EventListener {
         if (!plugin.isLocked(user.getUuid())) {
             plugin.lockPlayer(user.getUuid());
             plugin.getDataSyncer().syncSaveUserData(user);
+        } else {
+            plugin.debug(String.format("[%s] disconnected while locked - data will NOT be saved!",
+                    user.getName()));
         }
     }
 

--- a/common/src/main/java/net/william278/husksync/listener/LockedHandler.java
+++ b/common/src/main/java/net/william278/husksync/listener/LockedHandler.java
@@ -41,13 +41,18 @@ public interface LockedHandler {
     }
 
     /**
-     * Determine whether a player event should be canceled
+     * Determine whether a player event should be cancelled
      *
      * @param userUuid The UUID of the user to check
-     * @return Whether the event should be canceled
+     * @return Whether the event should be cancelled
      */
     default boolean cancelPlayerEvent(@NotNull UUID userUuid) {
-        return getPlugin().isDisabling() || getPlugin().isLocked(userUuid);
+        final boolean locked = getPlugin().isLocked(userUuid);
+        if (locked || getPlugin().isDisabling()) {
+            getPlugin().debug(String.format("[%s] cancelPlayerEvent: cancelled (locked=%s, disabling=%s)",
+                    userUuid, locked, getPlugin().isDisabling()));
+        }
+        return getPlugin().isDisabling() || locked;
     }
 
     @NotNull

--- a/common/src/main/java/net/william278/husksync/sync/LockstepDataSyncer.java
+++ b/common/src/main/java/net/william278/husksync/sync/LockstepDataSyncer.java
@@ -62,10 +62,14 @@ public class LockstepDataSyncer extends DataSyncer {
 
             // If they are checked in - or checked out on *this* server - we can apply their latest data
             getRedis().setUserCheckedOut(user, true);
-            getRedis().getUserData(user).ifPresentOrElse(
-                    data -> user.applySnapshot(data, DataSnapshot.UpdateCause.SYNCHRONIZED),
-                    () -> this.setUserFromDatabase(user)
-            );
+            final Optional<DataSnapshot.Packed> redisData = getRedis().getUserData(user);
+            if (redisData.isPresent()) {
+                plugin.debug(String.format("[%s] Applying data from Redis cache", user.getName()));
+                user.applySnapshot(redisData.get(), DataSnapshot.UpdateCause.SYNCHRONIZED);
+            } else {
+                plugin.debug(String.format("[%s] no Redis data; loading from database", user.getName()));
+                this.setUserFromDatabase(user);
+            }
             return true;
         });
     }

--- a/common/src/main/java/net/william278/husksync/user/OnlineUser.java
+++ b/common/src/main/java/net/william278/husksync/user/OnlineUser.java
@@ -32,6 +32,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 
 /**
  * Represents a logged-in {@link User}
@@ -86,7 +87,12 @@ public abstract class OnlineUser extends User implements CommandUser, UserDataHo
      * @param mineDown the parsed {@link MineDown} to send
      */
     public void sendMessage(@NotNull MineDown mineDown) {
-        sendMessage(mineDown.toComponent());
+        try {
+            sendMessage(mineDown.toComponent());
+        } catch (Throwable e) {
+            getPlugin().log(Level.WARNING,
+                    String.format("Failed to render MineDown message for %s", getName()), e);
+        }
     }
 
     /**
@@ -95,7 +101,12 @@ public abstract class OnlineUser extends User implements CommandUser, UserDataHo
      * @param mineDown the parsed {@link MineDown} to send
      */
     public void sendActionBar(@NotNull MineDown mineDown) {
-        getAudience().sendActionBar(mineDown.toComponent());
+        try {
+            getAudience().sendActionBar(mineDown.toComponent());
+        } catch (Throwable e) {
+            getPlugin().log(Level.WARNING,
+                    String.format("Failed to render MineDown action bar for %s", getName()), e);
+        }
     }
 
     /**
@@ -158,16 +169,26 @@ public abstract class OnlineUser extends User implements CommandUser, UserDataHo
      */
     public void completeSync(boolean succeeded, @NotNull DataSnapshot.UpdateCause cause, @NotNull HuskSync plugin) {
         if (succeeded) {
-            switch (plugin.getSettings().getSynchronization().getNotificationDisplaySlot()) {
-                case CHAT -> cause.getCompletedLocale(plugin).ifPresent(this::sendMessage);
-                case ACTION_BAR -> cause.getCompletedLocale(plugin).ifPresent(this::sendActionBar);
+            try {
+                switch (plugin.getSettings().getSynchronization().getNotificationDisplaySlot()) {
+                    case CHAT -> cause.getCompletedLocale(plugin).ifPresent(this::sendMessage);
+                    case ACTION_BAR -> cause.getCompletedLocale(plugin).ifPresent(this::sendActionBar);
+                }
+            } catch (Throwable e) {
+                plugin.log(Level.WARNING,
+                        String.format("Failed to send sync complete notification to %s", getName()), e);
             }
             plugin.fireEvent(
                     plugin.getSyncCompleteEvent(this),
                     (event) -> plugin.unlockPlayer(getUuid())
             );
         } else {
-            cause.getFailedLocale(plugin).ifPresent(this::sendMessage);
+            try {
+                cause.getFailedLocale(plugin).ifPresent(this::sendMessage);
+            } catch (Throwable e) {
+                plugin.log(Level.WARNING,
+                        String.format("Failed to send sync failure notification to %s", getName()), e);
+            }
         }
 
         // Ensure the user is in the database

--- a/common/src/main/java/net/william278/husksync/util/DataVersionSupplier.java
+++ b/common/src/main/java/net/william278/husksync/util/DataVersionSupplier.java
@@ -45,6 +45,7 @@ public interface DataVersionSupplier {
     int VERSION1_21_10 = 4556;
     int VERSION1_21_11 = 4671;
 	int VERSION26_1 = 4786;
+	int VERSION26_2 = 4903;
 
     /**
      * Returns the data version for a Minecraft version
@@ -74,7 +75,8 @@ public interface DataVersionSupplier {
             case "1.21.10" -> VERSION1_21_10;
             case "1.21.11" -> VERSION1_21_11;
 			case "26.1", "26.1.1", "26.1.2" -> VERSION26_1;
-			default -> VERSION26_1; // Latest supported version
+			case "26.2" -> VERSION26_2;
+			default -> VERSION26_2; // Latest supported version
         };
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.daemon=true
 javaVersion=25
 
 # Plugin metadata
-plugin_version=3.9.0
+plugin_version=4.0.0
 plugin_archive=husksync
 plugin_description=A modern, cross-server player data synchronization system
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 // Common

--- a/test/upgrade-husksync.py
+++ b/test/upgrade-husksync.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+# This script automates most changes required to target and support a specific Minecraft version
+
+"""
+Usage: python3 upgrade-husksync.py <version>   (e.g. upgrade-husksync.py 26.2)
+
+Creates/updates files for a new Minecraft version target:
+  - bukkit/<version>/gradle.properties
+  - common/.../DataVersionSupplier.java
+  - .github/workflows/ci.yml
+  - .github/workflows/release.yml
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+
+MCMETA_URL = "https://raw.githubusercontent.com/misode/mcmeta/summary/versions/data.json"
+PAPER_METADATA_URL = "https://repo.papermc.io/repository/maven-public/io/papermc/paper/paper-api/maven-metadata.xml"
+MANIFEST_URL = "https://piston-meta.mojang.com/mc/game/version_manifest_v2.json"
+JAVA_VERSION = "25"
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def fetch_json(url):
+    with urllib.request.urlopen(url) as r:
+        return json.loads(r.read().decode())
+
+
+def fetch_text(url):
+    with urllib.request.urlopen(url) as r:
+        return r.read().decode()
+
+
+def parse_version(version_str):
+    m = re.match(r"^(\d+)\.(\d+)(?:\.(\d+))?$", version_str)
+    if not m:
+        print(f"Error: '{version_str}' is not a valid Minecraft version (e.g. 26.1, 26.1.2)")
+        sys.exit(1)
+    major = int(m.group(1))
+    minor = int(m.group(2))
+    patch = int(m.group(3)) if m.group(3) else 0
+    return major, minor, patch
+
+
+def get_data_version(version_str):
+    data = fetch_json(MCMETA_URL)
+    for entry in data:
+        if entry.get("id") == version_str and entry.get("type") == "release":
+            return entry.get("data_version")
+    for entry in data:
+        if entry.get("id") == version_str:
+            return entry.get("data_version")
+    print(f"Error: version '{version_str}' not found in mcmeta versions data")
+    print(f"  Check available versions at {MCMETA_URL}")
+    sys.exit(1)
+
+
+def get_paper_api_version(version_str):
+    xml_text = fetch_text(PAPER_METADATA_URL)
+    root = ET.fromstring(xml_text)
+    all_versions = root.findall(".//version")
+
+    candidates = []
+    for v in all_versions:
+        ver = v.text
+        if ver and ver.startswith(f"{version_str}."):
+            m = re.search(r"\.build\.(\d+)", ver)
+            if m:
+                build_num = int(m.group(1))
+                channel = "alpha"
+                if "-stable" in ver.lower():
+                    channel = "stable"
+                elif "-beta" in ver.lower():
+                    channel = "beta"
+                candidates.append((build_num, channel, ver))
+
+    if not candidates:
+        print(f"Warning: no Paper API builds found for version {version_str}")
+        print(f"  Check {PAPER_METADATA_URL}")
+        print(f"  Falling back to '{version_str}.build.1-alpha'")
+        return f"{version_str}.build.1-alpha"
+
+    stable = [c for c in candidates if c[1] == "stable"]
+    beta = [c for c in candidates if c[1] == "beta"]
+    alpha = [c for c in candidates if c[1] == "alpha"]
+
+    if stable:
+        best = max(stable, key=lambda c: c[0])
+        print(f"  Paper API: STABLE build {best[2]}")
+        return best[2]
+    if beta:
+        best = max(beta, key=lambda c: c[0])
+        print(f"  Paper API: no STABLE, using BETA build {best[2]}")
+        return best[2]
+    best = max(alpha, key=lambda c: c[0])
+    print(f"  Paper API: no STABLE/BETA, using ALPHA build {best[2]}")
+    return best[2]
+
+
+def constant_name(major, minor):
+    return f"VERSION{major}_{minor}"
+
+
+def create_gradle_properties(version_str, api_version, numeric, version_range, paper_api):
+    dir_path = os.path.join(REPO_ROOT, "bukkit", version_str)
+    os.makedirs(dir_path, exist_ok=True)
+    path = os.path.join(dir_path, "gradle.properties")
+    content = (
+        f"minecraft_version_range={version_range}\n"
+        f"minecraft_version_numeric={numeric}\n"
+        f"minecraft_api_version={api_version}\n"
+        f"paper_api_version={paper_api}\n"
+        f"java_version={JAVA_VERSION}\n"
+    )
+    with open(path, "w") as f:
+        f.write(content)
+    print(f"  Created {path}")
+
+
+def edit_data_version_supplier(major, minor, data_version):
+    path = os.path.join(
+        REPO_ROOT, "common/src/main/java/net/william278/husksync/util",
+        "DataVersionSupplier.java"
+    )
+    with open(path) as f:
+        content = f.read()
+
+    const_name = constant_name(major, minor)
+    version_label = f"{major}.{minor}"
+
+    # 1. Add constant if not present
+    new_const = f"\tint {const_name} = {data_version};"
+    if new_const in content:
+        print(f"  Constant {const_name} already exists, skipping")
+    else:
+        const_pattern = r"(int VERSION\d+(?:_\d+)+ = \d+;)"
+        matches = list(re.finditer(const_pattern, content))
+        if not matches:
+            print("Error: could not find existing VERSION constants")
+            sys.exit(1)
+        insert_pos = matches[-1].end()
+        content = content[:insert_pos] + "\n" + new_const + content[insert_pos:]
+        print(f"  Added constant {const_name} = {data_version}")
+
+    # 2. Add switch case before default
+    new_case = f"case \"{version_label}\" -> {const_name};"
+    if new_case in content:
+        print(f"  Switch case for '{version_label}' already exists, skipping")
+    else:
+        default_match = re.search(r"(\t*default -> .*; // Latest supported version)", content)
+        if not default_match:
+            print("Error: could not find default case in switch")
+            sys.exit(1)
+        insert_pos = default_match.start()
+        content = content[:insert_pos] + f"\t\t\t{new_case}\n" + content[insert_pos:]
+        print(f"  Added switch case for '{version_label}'")
+
+    # 3. Update default to point to new constant
+    default_pattern = r"(default -> )(\w+)(; // Latest supported version)"
+    default_line = re.search(default_pattern, content)
+    if default_line:
+        content = content.replace(
+            default_line.group(0),
+            f"{default_line.group(1)}{const_name}{default_line.group(3)}"
+        )
+        print(f"  Updated default to {const_name}")
+
+    with open(path, "w") as f:
+        f.write(content)
+    print(f"  Updated {path}")
+
+
+def get_block_items(content, block_key):
+    """Return list of items (with leading whitespace) in a YAML list block."""
+    pattern = rf"^\s*{re.escape(block_key)}: \|\s*$"
+    match = re.search(pattern, content, re.MULTILINE)
+    if not match:
+        return []
+    block_start = match.end()
+    lines = content[block_start:].split("\n")
+    items = []
+    block_indent = None
+    for line in lines:
+        stripped = line.rstrip()
+        if not stripped:
+            continue
+        line_indent = len(line) - len(line.lstrip())
+        if block_indent is None:
+            block_indent = line_indent
+        if line_indent >= block_indent:
+            items.append(line.rstrip())
+        else:
+            break
+    return items
+
+
+def update_workflow(workflow_file, version_str):
+    """Append a new distro entry to a workflow file's publish step."""
+    path = os.path.join(REPO_ROOT, ".github/workflows", workflow_file)
+    with open(path) as f:
+        content = f.read()
+
+    version_tag = f"paper-{version_str}"
+    if version_tag in content:
+        print(f"  Distro {version_tag} already in {workflow_file}, skipping")
+        return
+
+    file_var = "env.version_name" if workflow_file == "ci.yml" else "github.event.release.tag_name"
+
+    # The 4 blocks are parallel arrays — ensure they all stay in sync
+    blocks = [
+        ("distro-names", version_tag),
+        ("distro-groups", "paper"),
+        ("distro-descriptions", f"Paper {version_str}"),
+        ("files", f"target/HuskSync-Bukkit-${{{{ {file_var} }}}}+mc.{version_str}.jar"),
+    ]
+
+    # Count entries in distro-names as the reference
+    ref_count = len(get_block_items(content, "distro-names"))
+
+    for block_key, new_line in blocks:
+        items = get_block_items(content, block_key)
+        if len(items) >= ref_count + 1:
+            print(f"    {block_key}: already has {len(items)} entries, skipping")
+            continue
+        if not items:
+            continue
+
+        # Determine the indent from the first item
+        item_indent = len(items[0]) - len(items[0].lstrip())
+        new_entry = " " * item_indent + new_line
+
+        # Insert after the last item in the block
+        block_pattern = rf"^\s*{re.escape(block_key)}: \|\s*$"
+        block_match = re.search(block_pattern, content, re.MULTILINE)
+        block_start = block_match.end()
+
+        insert_after = block_start
+        for _ in range(len(items)):
+            insert_after = content.index("\n", insert_after) + 1
+        content = content[:insert_after] + new_entry + "\n" + content[insert_after:]
+        print(f"    {block_key}: added '{new_line}'")
+
+    content = content.rstrip("\n") + "\n"
+
+    with open(path, "w") as f:
+        f.write(content)
+    print(f"  Updated {workflow_file}: added {version_tag}")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__)
+        try:
+            manifest = fetch_json(MANIFEST_URL)
+            print(f"\nLatest Minecraft release: {manifest['latest']['release']}")
+        except Exception:
+            pass
+        sys.exit(1)
+
+    version_str = sys.argv[1]
+    print(f"== Upgrading HuskSync to Minecraft {version_str} ==\n")
+
+    major, minor, patch = parse_version(version_str)
+    api_version = f"{major}.{minor}"
+    version_range = f">={version_str} <={version_str}"
+    numeric = major * 10000 + minor * 100 + patch
+
+    print(f"  Version:        {version_str}")
+    print(f"  API version:    {api_version}")
+    print(f"  Numeric:        {numeric}")
+    print(f"  Version range:  {version_range}")
+
+    print("\n--- Fetching data version ---")
+    data_version = get_data_version(version_str)
+    print(f"  Data version:   {data_version}")
+
+    print("\n--- Fetching Paper API version ---")
+    paper_api = get_paper_api_version(version_str)
+
+    print("\n--- Bukkit gradle.properties ---")
+    create_gradle_properties(version_str, api_version, numeric, version_range, paper_api)
+
+    print("\n--- DataVersionSupplier.java ---")
+    edit_data_version_supplier(major, minor, data_version)
+
+    print("\n--- CI workflow ---")
+    update_workflow("ci.yml", version_str)
+
+    print("\n--- Release workflow ---")
+    update_workflow("release.yml", version_str)
+
+    print(f"\n== Upgrade to {version_str} complete ==")
+    print("Review changes with: git diff")
+    print('Commit: git add -A && git commit -m "feat: add Paper {} support"'.format(version_str))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Adds streamlined 26.2 support in order to not have the plugin crash on startup
  - N.B. This bypasses the net-api preload checks, solely as a proof of concept of HuskSync working on 26.2
- Adds simple `upgrade-husksync,py` script to automate base level of changes required for a new HuskSync version