### PR TITLE
Fix snapshot deserialize failures and stat startup CPU

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
@@ -439,6 +439,28 @@ public abstract class BukkitData implements Data {
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Statistics extends BukkitData implements Data.Statistics, Adaptable {
 
+        // Pre-filtered material lists to avoid N×M iteration over the full Registry.MATERIAL per statistic type
+        private static Set<Material> BLOCK_MATERIALS;
+        private static Set<Material> ITEM_MATERIALS;
+
+        private static Set<Material> getBlockMaterials() {
+            if (BLOCK_MATERIALS == null) {
+                final Set<Material> blocks = new HashSet<>();
+                Registry.MATERIAL.forEach(mat -> { if (mat.isBlock()) blocks.add(mat); });
+                BLOCK_MATERIALS = Collections.unmodifiableSet(blocks);
+            }
+            return BLOCK_MATERIALS;
+        }
+
+        private static Set<Material> getItemMaterials() {
+            if (ITEM_MATERIALS == null) {
+                final Set<Material> items = new HashSet<>();
+                Registry.MATERIAL.forEach(mat -> { if (mat.isItem()) items.add(mat); });
+                ITEM_MATERIALS = Collections.unmodifiableSet(items);
+            }
+            return ITEM_MATERIALS;
+        }
+
         @SerializedName("generic")
         private Map<String, Integer> genericStatistics;
         @SerializedName("blocks")
@@ -457,8 +479,8 @@ public abstract class BukkitData implements Data {
                 switch (id.getType()) {
                     case UNTYPED -> addStatistic(player, id, generic);
                     // Todo - Future - Use BLOCK and ITEM registries when API stabilizes
-                    case BLOCK -> addStatistic(player, id, Registry.MATERIAL, blocks);
-                    case ITEM -> addStatistic(player, id, Registry.MATERIAL, items);
+                    case BLOCK -> addStatistic(player, id, getBlockMaterials(), blocks);
+                    case ITEM -> addStatistic(player, id, getItemMaterials(), items);
                     case ENTITY -> addStatistic(player, id, Registry.ENTITY_TYPE, entities);
                 }
             });
@@ -481,7 +503,7 @@ public abstract class BukkitData implements Data {
         }
 
         private static <R extends Keyed> void addStatistic(@NotNull Player p, @NotNull Statistic id,
-                                                           @NotNull Registry<R> registry,
+                                                           @NotNull Iterable<R> registry,
                                                            @NotNull Map<String, Map<String, Integer>> map) {
             registry.forEach(i -> {
                 try {

--- a/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
+++ b/common/src/main/java/net/william278/husksync/data/DataSnapshot.java
@@ -40,6 +40,7 @@ import org.jetbrains.annotations.Nullable;
 import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 /**
@@ -390,15 +391,23 @@ public class DataSnapshot {
         @NotNull
         @ApiStatus.Internal
         private Map<Identifier, Data> deserializeData(@NotNull HuskSync plugin) {
-            return data.entrySet().stream()
+            final Map<Identifier, Data> result = new HashMap<>();
+            data.entrySet().stream()
                     .filter(e -> plugin.getIdentifier(e.getKey()).isPresent())
                     .map(entry -> Map.entry(plugin.getIdentifier(entry.getKey()).orElseThrow(), entry.getValue()))
-                    .collect(Collectors.toMap(
-                            Map.Entry::getKey,
-                            entry -> plugin.deserializeData(entry.getKey(), entry.getValue(), getMinecraftVersion()),
-                            (a, b) -> a,
-                            HashMap::new
-                    ));
+                    .forEach(entry -> {
+                        try {
+                            result.put(entry.getKey(), plugin.deserializeData(
+                                    entry.getKey(), entry.getValue(), getMinecraftVersion()));
+                        } catch (Throwable e) {
+                            plugin.log(Level.WARNING,
+                                    "Failed to deserialize %s data for snapshot %s; skipping it. "
+                                            + "The data may contain invalid values (e.g. items with -Infinity NBT attributes). "
+                                            + "The player will load without this data type for this session."
+                                            .formatted(entry.getKey(), getId()), e);
+                        }
+                    });
+            return result;
         }
 
         @NotNull


### PR DESCRIPTION
Adopts the fixes used by several forks for the following bugs:
- `DataSnapshot.deserializeData`: catch per-type errors so a corrupt data type (e.g. -Infinity NBT attribute) no longer blocks player login; load remaining types and warn (https://github.com/WiIIiam278/HuskSync/issues/584)
- BukkitData Statistics: pre-filter `Registry.MATERIAL` into block-only and item-only sets at first use to avoid N*M iteration spikes (https://github.com/WiIIiam278/HuskSync/issues/588)