### PR TITLE
Fix DependencyOrderComparator causing incorrect snapshot application order

### DIFF
--- a/common/src/main/java/net/william278/husksync/data/Data.java
+++ b/common/src/main/java/net/william278/husksync/data/Data.java
@@ -375,6 +375,7 @@ public interface Data {
 
             @Deprecated(since = "3.7")
             public Modifier(@NotNull UUID uuid, @NotNull String name, double amount, int operation, int equipmentSlot) {
+                this.uuid = uuid;
                 this.name = name;
                 this.amount = amount;
                 this.operation = operation;

--- a/common/src/main/java/net/william278/husksync/data/Identifier.java
+++ b/common/src/main/java/net/william278/husksync/data/Identifier.java
@@ -307,7 +307,10 @@ public class Identifier implements Comparable<Identifier> {
                 }
                 return 1;
             }
-            return -1;
+            if (i2.dependsOn(i1)) {
+                return -1;
+            }
+            return i1.compareTo(i2);
         }
 
     }


### PR DESCRIPTION
Aims to address issue #687 

For posterity: `DependencyOrderComparator.compare()` currently only checks if i1 depends on i2 — if not, it will return -1 without checking the reverse direction. For unrelated identifiers (INVENTORY vs POTION_EFFECTS), this meant compare(A, B) and compare(B, A) both returned -1, and in a TreeMap this can produce unpredictable ordering and silently drop entries.

This fix simply adds the missing `i2.dependsOn(i1)` check and should fall back to key-based comparison (compareTo) when neither identifier depends on the other, hopefully making the comparator symmetric and deterministic.

This caused ATTRIBUTES to be applied before INVENTORY during snapshot application, so attribute modifiers from armour items could be cleared before the armour was even equipped or left unsaved modifiers to be overwritten.