### PR TITLE
Fix inv order on MC updates

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitSerializer.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitSerializer.java
@@ -157,8 +157,8 @@ public class BukkitSerializer {
                         upgraded = new ItemStack(Material.AIR);
                     }
                 }
-                if(upgraded != null && !upgraded.isEmpty()) {
-                    if(slot < itemStacks.length && (itemStacks[slot] == null || itemStacks[slot].isEmpty())) {
+                if (upgraded != null && !upgraded.isEmpty()) {
+                    if (slot < itemStacks.length && (itemStacks[slot] == null || itemStacks[slot].isEmpty())) {
                         itemStacks[slot] = upgraded;
                     } else {
                         overFlow.add(upgraded);
@@ -166,17 +166,17 @@ public class BukkitSerializer {
                 }
             }
 
-            for(ItemStack remaining : overFlow) {
-                for(int i = 0; i < itemStacks.length; i++) {
-                    if(itemStacks[i] == null || itemStacks[i].isEmpty()) {
+            for (ItemStack remaining : overFlow) {
+                for (int i = 0; i < itemStacks.length; i++) {
+                    if (itemStacks[i] == null || itemStacks[i].isEmpty()) {
                         itemStacks[i] = remaining;
                         break;
                     }
                 }
             }
 
-            for(int i = 0; i < itemStacks.length; i++) {
-                if(itemStacks[i] == null) {
+            for (int i = 0; i < itemStacks.length; i++) {
+                if (itemStacks[i] == null) {
                     itemStacks[i] = new ItemStack(Material.AIR);
                 }
             }

--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitSerializer.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitSerializer.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static net.william278.husksync.data.BukkitData.Items.Inventory.INVENTORY_SLOT_COUNT;

--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitSerializer.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitSerializer.java
@@ -136,14 +136,47 @@ public class BukkitSerializer {
         private ItemStack @NotNull [] upgradeItemStacks(@NotNull NBTCompound itemsNbt, @NotNull Version mcVersion) {
             final ReadWriteNBTCompoundList items = itemsNbt.getCompoundList("items");
             final ItemStack[] itemStacks = new ItemStack[itemsNbt.getInteger("size")];
+            final List<ItemStack> overFlow = new ArrayList<>();
             for (int i = 0; i < items.size(); i++) {
-                if (items.get(i) == null) {
-                    itemStacks[i] = new ItemStack(Material.AIR);
+                final ReadWriteNBT item = items.get(i);
+                if (item == null) {
                     continue;
                 }
+                final int slot = item.hasTag("Slot") ? item.getInteger("Slot") : i;
+                if (slot < 0) {
+                    continue;
+                }
+
+                ItemStack upgraded = null;
                 try {
-                    itemStacks[i] = NBT.itemStackFromNBT(upgradeItemData(items.get(i), mcVersion));
+                    upgraded = NBT.itemStackFromNBT(upgradeItemData(item, mcVersion));
                 } catch (Throwable e) {
+                    try {
+                        upgraded = NBT.itemStackFromNBT(item);
+                    } catch (Throwable e2) {
+                        upgraded = new ItemStack(Material.AIR);
+                    }
+                }
+                if(upgraded != null && !upgraded.isEmpty()) {
+                    if(slot < itemStacks.length && (itemStacks[slot] == null || itemStacks[slot].isEmpty())) {
+                        itemStacks[slot] = upgraded;
+                    } else {
+                        overFlow.add(upgraded);
+                    }
+                }
+            }
+
+            for(ItemStack remaining : overFlow) {
+                for(int i = 0; i < itemStacks.length; i++) {
+                    if(itemStacks[i] == null || itemStacks[i].isEmpty()) {
+                        itemStacks[i] = remaining;
+                        break;
+                    }
+                }
+            }
+
+            for(int i = 0; i < itemStacks.length; i++) {
+                if(itemStacks[i] == null) {
                     itemStacks[i] = new ItemStack(Material.AIR);
                 }
             }


### PR DESCRIPTION
Fixes #689 

Instead of setting items by iterator index, we're now reading the NBT "Slot" value. If an item doesn't have any Slot value (which I never saw), or if two items have the same slot (which I also never saw), they're added to an "overflow" list, and then added back into empty slots.

Tested on 1.21.11 -> 26.1.2 without issues