### PR TITLE
Readd 1.21.11 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,14 +51,18 @@ jobs:
           version: ${{ env.version_name }}
           changelog: ${{ github.event.head_commit.message }}
           distro-names: |
+            paper-1.21.11
             paper-26.2
             paper-26.1.2
           distro-groups: |
             paper
             paper
+            paper
           distro-descriptions: |
+            Paper 1.21.11
             Paper 26.2
             Paper 26.1.2
           files: |
+            target/HuskSync-Bukkit-${{ env.version_name }}+mc.1.21.11.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.26.2.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.26.1.2.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,14 +40,18 @@ jobs:
           version: ${{ github.event.release.tag_name }}
           changelog: ${{ github.event.release.body }}
           distro-names: |
+            paper-1.21.11
             paper-26.2
             paper-26.1.2
           distro-groups: |
             paper
             paper
+            paper
           distro-descriptions: |
+            Paper 1.21.11
             Paper 26.2
             Paper 26.1.2
           files: |
+            target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.1.21.11.jar
             target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.26.2.jar
             target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.26.1.2.jar

--- a/bukkit/1.21.11/gradle.properties
+++ b/bukkit/1.21.11/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version_range=>=1.21.11 <=1.21.11
+minecraft_version_numeric=12111
+minecraft_api_version=1.21
+paper_api_version=1.21.11-R0.1-SNAPSHOT
+java_version=21


### PR DESCRIPTION
With ci pipelines now working as expected with the latest set of minimum builds, this PR reads support for 1.21.11 with the goal of providing a working Release version build on the site