### PR TITLE
Server crash on Folia

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
+++ b/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
@@ -260,7 +260,7 @@ public class BukkitHuskSync extends JavaPlugin implements HuskSync, BukkitTask.S
     @Override
     @NotNull
     public Set<OnlineUser> getOnlineUsers() {
-        return getServer().getOnlinePlayers().stream()
+        return new ArrayList<>(getServer().getOnlinePlayers()).stream()
                 .map(player -> BukkitUser.adapt(player, this))
                 .collect(Collectors.toSet());
     }


### PR DESCRIPTION
Accessing online player list throws concurrent modification exception in rare cases. This fix prevents that issue.