### PR TITLE
Add support for environment variable to configure server name

### DIFF
--- a/common/src/main/java/net/william278/husksync/config/ConfigProvider.java
+++ b/common/src/main/java/net/william278/husksync/config/ConfigProvider.java
@@ -140,6 +140,13 @@ public interface ConfigProvider {
                 Server.class,
                 YAML_CONFIGURATION_PROPERTIES.header(Server.CONFIG_HEADER).build()
         ));
+
+        String envServerName = System.getenv("HUSKSYNC_SERVER_NAME");
+        if (envServerName != null && !envServerName.isEmpty()) {
+            Server server = Server.of(envServerName);
+            setServerName(server);
+            getPlugin().log(Level.INFO, "Server name set to: " + envServerName);
+        }
     }
 
     default void validateConfigFiles() {

--- a/common/src/main/java/net/william278/husksync/config/Server.java
+++ b/common/src/main/java/net/william278/husksync/config/Server.java
@@ -38,7 +38,8 @@ public class Server {
             ┃    Developed by William278   ┃
             ┣━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
             ┣╸ This file should contain the ID of this server as defined in your proxy config.
-            ┗╸ If you join it using /server alpha, then set it to 'alpha' (case-sensitive)""";
+            ┣╸ If you join it using /server alpha, then set it to 'alpha' (case-sensitive)
+            ┗╸ You can also set the environment variable HUSKSYNC_SERVER_NAME to override this value""";
 
     private String name = getDefault();
 


### PR DESCRIPTION
Add support for environment variable to configure server name. It is highly beneficial servers like us to configure the server name property easily.