### PR TITLE
Fix multi-line locale and PaginatedList formatting for MiniMessage

### DIFF
--- a/common/src/main/java/net/william278/husksync/config/Locales.java
+++ b/common/src/main/java/net/william278/husksync/config/Locales.java
@@ -26,7 +26,6 @@ import lombok.NoArgsConstructor;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.william278.husksync.util.PaginatedList;
-import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
@@ -69,7 +68,7 @@ public class Locales {
      * @return An {@link Optional} containing the locale corresponding to the id, if it exists
      */
     public Optional<String> getRawLocale(@NotNull String localeId) {
-        return Optional.ofNullable(locales.get(localeId)).map(StringEscapeUtils::unescapeJava);
+        return Optional.ofNullable(locales.get(localeId)).map(Locales::unescapeLocale);
     }
 
     /**
@@ -116,6 +115,32 @@ public class Locales {
     @NotNull
     public Component format(@NotNull String text) {
         return MiniMessage.miniMessage().deserialize(text);
+    }
+
+    /**
+     * Unescape a raw locale string loaded from YAML.
+     * <p>
+     * Leaves {@code \\}, {@code \'} and {@code \"} untouched, since these belong to
+     * MiniMessage's own quoted-argument escaping (e.g. {@code hover:show_text:'it\'s'}).
+     * <p>
+     * Leaves {@code \n}, since YAML translations use it to force a line break.
+     *
+     * @param string The raw string as loaded from the locale file
+     * @return The string with {@code \n} escapes resolved
+     */
+    @NotNull
+    private static String unescapeLocale(@NotNull String string) {
+        final StringBuilder out = new StringBuilder(string.length());
+        for (int i = 0; i < string.length(); i++) {
+            final char c = string.charAt(i);
+            if (c == '\\' && i + 1 < string.length() && string.charAt(i + 1) == 'n') {
+                out.append('\n');
+                i++;
+            } else {
+                out.append(c);
+            }
+        }
+        return out.toString();
     }
 
     /**

--- a/common/src/main/java/net/william278/husksync/util/DataSnapshotList.java
+++ b/common/src/main/java/net/william278/husksync/util/DataSnapshotList.java
@@ -44,29 +44,30 @@ public class DataSnapshotList {
     private DataSnapshotList(@NotNull List<DataSnapshot.Packed> snapshots, @NotNull User dataOwner,
                              @NotNull HuskSync plugin) {
         final AtomicInteger snapshotNumber = new AtomicInteger(1);
-        this.paginatedList = plugin.getLocales().getBaseChatList(6)
-                .setItems(snapshots.stream()
-                        .map(snapshot -> plugin.getLocales()
-                                .getRawLocale(!snapshot.isInvalid() ? "data_list_item" : "data_list_item_invalid",
-                                        getNumberIcon(snapshotNumber.getAndIncrement()),
-                                        dataOwner.getName(),
-                                        snapshot.getId().toString(),
-                                        snapshot.getShortId(),
-                                        snapshot.isPinned() ? "※" : "  ",
-                                        snapshot.getTimestamp().format(DateTimeFormatter
-                                                .ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)),
-                                        snapshot.getTimestamp().format(DateTimeFormatter
-                                                .ofLocalizedDateTime(FormatStyle.LONG, FormatStyle.MEDIUM)),
-                                        snapshot.getSaveCause().getLocale(plugin),
-                                        String.format("%.2fKiB", snapshot.getFileSize(plugin) / 1024f),
-                                        snapshot.isInvalid() ? snapshot.getInvalidReason(plugin) : "")
-                                .orElse("• " + snapshot.getId())).toList())
-                .setHeaderFormat(plugin.getLocales()
-                        .getRawLocale("data_list_title", dataOwner.getName(),
-                                "%first_item_on_page_index%", "%last_item_on_page_index%", "%total_items%")
-                        .orElse(""))
-                .setCommand("/husksync:userdata list " + dataOwner.getName())
-                .build();
+        this.paginatedList = PaginatedList.of(snapshots.stream()
+                .map(snapshot -> plugin.getLocales()
+                        .getRawLocale(!snapshot.isInvalid() ? "data_list_item" : "data_list_item_invalid",
+                                getNumberIcon(snapshotNumber.getAndIncrement()),
+                                dataOwner.getName(),
+                                snapshot.getId().toString(),
+                                snapshot.getShortId(),
+                                snapshot.isPinned() ? "※" : "  ",
+                                snapshot.getTimestamp().format(DateTimeFormatter
+                                        .ofLocalizedDateTime(FormatStyle.MEDIUM, FormatStyle.SHORT)),
+                                snapshot.getTimestamp().format(DateTimeFormatter
+                                        .ofLocalizedDateTime(FormatStyle.LONG, FormatStyle.MEDIUM)),
+                                snapshot.getSaveCause().getLocale(plugin),
+                                String.format("%.2fKiB", snapshot.getFileSize(plugin) / 1024f),
+                                snapshot.isInvalid() ? snapshot.getInvalidReason(plugin) : "")
+                        .orElse("• " + snapshot.getId()))
+                .toList(),
+                plugin.getLocales().getBaseChatList(6)
+                        .setHeaderFormat(plugin.getLocales()
+                                .getRawLocale("data_list_title", dataOwner.getName(),
+                                        "%first_item_on_page_index%", "%last_item_on_page_index%", "%total_items%")
+                                .orElse(""))
+                        .setCommand("/husksync:userdata list " + dataOwner.getName())
+                        .build());
     }
 
     /**

--- a/common/src/main/java/net/william278/husksync/util/PaginatedList.java
+++ b/common/src/main/java/net/william278/husksync/util/PaginatedList.java
@@ -62,6 +62,24 @@ public class PaginatedList {
         return (int) Math.ceil((double) items.size() / itemsPerPage);
     }
 
+    @NotNull
+    public static PaginatedList of(@NotNull List<String> items, @NotNull PaginatedList template) {
+        return new Builder()
+                .setItems(items)
+                .setItemsPerPage(template.itemsPerPage)
+                .setHeaderFormat(template.headerFormat)
+                .setFooterFormat(template.footerFormat)
+                .setPreviousButtonFormat(template.previousButtonFormat)
+                .setNextButtonFormat(template.nextButtonFormat)
+                .setPageJumpersFormat(template.pageJumpersFormat)
+                .setPageJumperPageFormat(template.pageJumperPageFormat)
+                .setPageJumperCurrentPageFormat(template.pageJumperCurrentPageFormat)
+                .setPageJumperPageSeparator(template.pageJumperSeparator)
+                .setPageJumperGroupSeparator(template.pageJumperGroupSeparator)
+                .setCommand(template.command)
+                .build();
+    }
+
     public Component getNearestValidPage(int page) {
         final int totalPages = getTotalPages();
         final int clampedPage = Math.max(1, Math.min(page, Math.max(1, totalPages)));
@@ -69,15 +87,18 @@ public class PaginatedList {
         final MiniMessage mm = MiniMessage.miniMessage();
         final List<Component> lines = new ArrayList<>();
 
+        final int startIndex = (clampedPage - 1) * itemsPerPage;
+        final int endIndex = Math.min(startIndex + itemsPerPage, items.size());
+
         if (headerFormat != null && !headerFormat.isEmpty()) {
             lines.add(mm.deserialize(headerFormat
                     .replace("%current_page%", Integer.toString(clampedPage))
                     .replace("%total_pages%", Integer.toString(totalPages))
-                    .replace("%total_items%", Integer.toString(items.size()))));
+                    .replace("%total_items%", Integer.toString(items.size()))
+                    .replace("%first_item_on_page_index%", Integer.toString(items.isEmpty() ? 0 : startIndex + 1))
+                    .replace("%last_item_on_page_index%", Integer.toString(endIndex))));
         }
 
-        final int startIndex = (clampedPage - 1) * itemsPerPage;
-        final int endIndex = Math.min(startIndex + itemsPerPage, items.size());
         IntStream.range(startIndex, endIndex)
                 .mapToObj(i -> mm.deserialize(items.get(i)))
                 .forEach(lines::add);
@@ -86,12 +107,12 @@ public class PaginatedList {
             final String previousButton = previousButtonFormat != null && clampedPage > 1
                     ? mm.serialize(mm.deserialize(previousButtonFormat
                     .replace("%previous_page_index%", Integer.toString(clampedPage - 1))
-                    .replace("%command%", command)))
+                    .replace("%command%", command + " " + (clampedPage - 1))))
                     : "";
             final String nextButton = nextButtonFormat != null && clampedPage < totalPages
                     ? mm.serialize(mm.deserialize(nextButtonFormat
                     .replace("%next_page_index%", Integer.toString(clampedPage + 1))
-                    .replace("%command%", command)))
+                    .replace("%command%", command + " " + (clampedPage + 1))))
                     : "";
             final String pageJumpers = buildPageJumpers(mm, clampedPage, totalPages);
 
@@ -122,7 +143,7 @@ public class PaginatedList {
             final String format = (i == currentPage) ? pageJumperCurrentPageFormat : pageJumperPageFormat;
             final String rendered = mm.serialize(mm.deserialize(format
                     .replace("%target_page_index%", Integer.toString(i))
-                    .replace("%command%", command)
+                    .replace("%command%", command + " " + i)
                     .replace("%current_page%", Integer.toString(i))));
             jumpButtons.add(rendered);
         }


### PR DESCRIPTION
Fixes two issues seen with the removal of MiniMessage:
- Multi-line locale text format does not get correctly escaped
- Jumping to new pages in `/husksync:playerdata view <x>` does not work