### PR TITLE
Readd 1.21.10 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,7 @@ jobs:
           version: ${{ env.version_name }}
           changelog: ${{ github.event.head_commit.message }}
           distro-names: |
+            paper-1.21.10
             paper-1.21.11
             paper-26.2
             paper-26.1.2
@@ -59,10 +60,12 @@ jobs:
             paper
             paper
           distro-descriptions: |
+            Paper 1.21.10
             Paper 1.21.11
             Paper 26.2
             Paper 26.1.2
           files: |
+            target/HuskSync-Bukkit-${{ env.version_name }}+mc.1.21.10.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.1.21.11.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.26.2.jar
             target/HuskSync-Bukkit-${{ env.version_name }}+mc.26.1.2.jar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
           version: ${{ github.event.release.tag_name }}
           changelog: ${{ github.event.release.body }}
           distro-names: |
+            paper-1.21.10
             paper-1.21.11
             paper-26.2
             paper-26.1.2
@@ -48,10 +49,12 @@ jobs:
             paper
             paper
           distro-descriptions: |
+            Paper 1.21.10
             Paper 1.21.11
             Paper 26.2
             Paper 26.1.2
           files: |
+            target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.1.21.10.jar
             target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.1.21.11.jar
             target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.26.2.jar
             target/HuskSync-Bukkit-${{ github.event.release.tag_name }}+mc.26.1.2.jar

--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ HuskSync supports the following [compatible versions](https://william278.net/doc
 |    Minecraft    | Latest HuskSync | Java Version | Platforms     | Support Status                |
 |:---------------:|:---------------:|:------------:|:--------------|:------------------------------|
 |     26.1.2    |    _latest_   |      25      | Paper         |     ✅ **Active Release**      |
-|     1.21.11   |    3.8.7     |      21      | Paper            | 🗃️ Archived (June 2026)      |
-|     1.21.10   |      3.8.7      |      21      | Paper         | 🗃️ Archived (June 2026)      |
-|     1.21.10   |      3.8.7      |      21      | Paper         | 🗃️ Archived (June 2026)      |
-|    1.21.7/8   |      3.8.7      |      21      | Paper, Fabric | 🗃️ Archived (June 2026)      |
+|     1.21.11   |    3.8.7     |      21      | Paper            | 🗃️ Archived (July 2026)      |
+|     1.21.10   |      3.8.7      |      21      | Paper         | 🗃️ Archived (July 2026)      |
+|     1.21.10   |      3.8.7      |      21      | Paper         | 🗃️ Archived (July 2026)      |
+|    1.21.7/8   |      3.8.7      |      21      | Paper, Fabric | 🗃️ Archived (July 2026)      |
 |     1.21.6    |      3.8.5      |      21      | Paper         | 🗃️ Archived (July 2025)      |
 |     1.21.5    |      3.8.7      |      21      | Paper         | 🗃️ Archived (June 2026)      |
 |     1.21.4    |      3.8.7      |      21      | Paper, Fabric | 🗃️ Archived (June 2026)      |

--- a/bukkit/1.21.10/gradle.properties
+++ b/bukkit/1.21.10/gradle.properties
@@ -1,0 +1,5 @@
+minecraft_version_range=>=1.21.11 <=1.21.11
+minecraft_version_numeric=12111
+minecraft_api_version=1.21
+paper_api_version=1.21.11-R0.1-SNAPSHOT
+java_version=21

--- a/bukkit/1.21.11/gradle.properties
+++ b/bukkit/1.21.11/gradle.properties
@@ -1,5 +1,5 @@
-minecraft_version_range=>=1.21.11 <=1.21.11
-minecraft_version_numeric=12111
+minecraft_version_range=>=1.21.10 <=1.21.10
+minecraft_version_numeric=12110
 minecraft_api_version=1.21
-paper_api_version=1.21.11-R0.1-SNAPSHOT
+paper_api_version=1.21.10-R0.1-SNAPSHOT
 java_version=21


### PR DESCRIPTION
With ci pipelines now working as expected with the latest set of minimum builds, this PR reads support for 1.21.10 with the goal of providing a working Release version build on the site