### PR TITLE
Muting advancements

### DIFF
--- a/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
+++ b/bukkit/src/main/java/net/william278/husksync/BukkitHuskSync.java
@@ -46,6 +46,7 @@ import net.william278.husksync.database.MySqlDatabase;
 import net.william278.husksync.database.PostgresDatabase;
 import net.william278.husksync.event.BukkitEventDispatcher;
 import net.william278.husksync.hook.PlanHook;
+import net.william278.husksync.listener.BukkitAdvancementAnnounceMuter;
 import net.william278.husksync.listener.BukkitEventListener;
 import net.william278.husksync.listener.LockedHandler;
 import net.william278.husksync.maps.BukkitMapHandler;
@@ -215,6 +216,13 @@ public class BukkitHuskSync extends JavaPlugin implements HuskSync, BukkitTask.S
 
         // Register events
         initialize("events", (plugin) -> eventListener.onEnable());
+        
+     // Mute advancement re-announcement on sync
+        initialize("advancement announce muter", (plugin) -> {
+            if (isDependencyLoaded("ProtocolLib")) {
+                BukkitAdvancementAnnounceMuter.register(this);
+            }
+        });
 
         // Register plugin hooks
         initialize("hooks", (plugin) -> {

--- a/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
+++ b/bukkit/src/main/java/net/william278/husksync/data/BukkitData.java
@@ -50,13 +50,13 @@ import org.jetbrains.annotations.Range;
 import org.jetbrains.annotations.Unmodifiable;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 import static net.william278.husksync.util.BukkitKeyedAdapter.*;
 
 public abstract class BukkitData implements Data {
-
     @Override
     public final void apply(@NotNull UserDataHolder dataHolder, @NotNull HuskSync plugin) throws IllegalStateException {
         this.apply((BukkitUser) dataHolder, (BukkitHuskSync) plugin);
@@ -298,6 +298,7 @@ public abstract class BukkitData implements Data {
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     public static class Advancements extends BukkitData implements Data.Advancements {
+        public static final Set<UUID> SUPPRESS_ANNOUNCE = ConcurrentHashMap.newKeySet();
 
         private List<Advancement> completed;
 
@@ -360,6 +361,13 @@ public abstract class BukkitData implements Data {
 
                 // Award and revoke advancement criteria
                 final AdvancementProgress progress = player.getAdvancementProgress(advancement);
+                
+                if (!toAward.isEmpty()) {
+                    SUPPRESS_ANNOUNCE.add(player.getUniqueId());
+                    Bukkit.getScheduler().runTaskLater((BukkitHuskSync) plugin,
+                            () -> SUPPRESS_ANNOUNCE.remove(player.getUniqueId()), 5L);
+                }
+                
                 toAward.forEach(progress::awardCriteria);
                 toRevoke.forEach(progress::revokeCriteria);
 

--- a/bukkit/src/main/java/net/william278/husksync/listener/BukkitAdvancementAnnounceMuter.java
+++ b/bukkit/src/main/java/net/william278/husksync/listener/BukkitAdvancementAnnounceMuter.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of HuskSync, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.husksync.listener;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.ListenerPriority;
+import com.comphenix.protocol.events.PacketAdapter;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.WrappedChatComponent;
+import net.william278.husksync.BukkitHuskSync;
+import net.william278.husksync.data.BukkitData;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+public class BukkitAdvancementAnnounceMuter {
+
+    public static void register(@NotNull BukkitHuskSync plugin) {
+        ProtocolLibrary.getProtocolManager().addPacketListener(new PacketAdapter(
+                plugin, ListenerPriority.NORMAL, PacketType.Play.Server.SYSTEM_CHAT) {
+            @Override
+            public void onPacketSending(PacketEvent event) {
+                final WrappedChatComponent chat = event.getPacket().getChatComponents().readSafely(0);
+                if (chat == null) return;
+                final String json = chat.getJson();
+                if (json == null || !json.contains("\"chat.type.advancement")) return;
+
+                for (UUID uuid : BukkitData.Advancements.SUPPRESS_ANNOUNCE) {
+                    final Player p = Bukkit.getPlayer(uuid);
+                    if (p != null && json.contains("\"" + p.getName() + "\"")) {
+                        event.setCancelled(true);
+                        return;
+                    }
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
This commit mutes advancements granted to the player by HuskSync, restoring vanilla behaviour of advancements only being announced once