### PR TITLE
Подстановка переменных среды в config.yml

### DIFF
--- a/.github/workflows/xmine-publish.yml
+++ b/.github/workflows/xmine-publish.yml
@@ -1,0 +1,185 @@
+# Публикация нашей сборки HuskSync в свой Reposilite, раздел third-party -
+# тот же, откуда её фактически берёт XMineNode (plugins/common.yml, координата
+# ru.xmine.thirdparty:husksync). Сейчас там лежит зеркало апстримного релиза
+# (4.0.0-26.1.2), а не сборка форка - этот workflow публикует именно сборку
+# форка, под координатой, неотличимой ни от апстрима (4.0.0), ни от
+# уже лежащего зеркала (4.0.0-26.1.2).
+#
+# ЭТОТ РЕПОЗИТОРИЙ ПУБЛИЧНЫЙ, поэтому `runs-on` здесь - только раннеры GitHub
+# и никогда `self-hosted`. Правило записано в вики (infra/ci.md, «Граница
+# безопасности: только приватные репозитории»), и обе группы раннеров
+# организации имеют `allows_public_repositories=false`. Причина в том, что PR
+# из чужого форка исполняет workflow ИЗ САМОГО PR, то есть автор форка волен
+# дописать `runs-on: self-hosted` и получить исполнение своего кода на хосте,
+# где работает игровой сервер. У `XMineServer/Paper`, `LibertyBans` и
+# `SkinsRestorer` тот же комментарий и та же причина.
+#
+# Отсюда же остальные меры: триггера `pull_request` нет вовсе, push (когда он
+# появится - см. ниже) ограничен нашими ветками, а job не запускается в форках
+# самого форка.
+#
+# Секреты называются MAVEN_USERNAME / MAVEN_PASSWORD - так их завёл владелец
+# именно в этом репозитории (как в CoreProtect). В SkinsRestorer и LibertyBans
+# те же по смыслу секреты называются XMINE_MAVEN_USERNAME / XMINE_MAVEN_PASSWORD.
+# Расхождение не унифицировано умышленно: заводить третье имя ради
+# единообразия хуже, чем один раз проверить, как называется секрет в
+# конкретном репозитории. Здесь они, что немаловажно для абзаца ниже, УЖЕ
+# заведены владельцем.
+#
+# ⚠ Триггера `push: branches: ['xmine/**']`, который есть у LibertyBans и
+# SkinsRestorer, здесь СОЗНАТЕЛЬНО пока нет - только workflow_dispatch. Ветка
+# уже называется xmine/env-config (переименована в этом же коммите), секреты
+# уже на месте, и если бы push-триггер был здесь с самого начала, то ЭТОТ ЖЕ
+# коммит, добавляющий файл, сам вызвал бы первую публикацию: GitHub match'ит
+# `on.push.branches` по дереву запушенного коммита, а не по тому, что было
+# на ветке раньше. Проверено эмпирически прямо на этом репозитории:
+# пробный workflow с `on: push: branches: ['probe/**']`, запушенный на
+# другое имя, затем переименованный (POST .../branches/{b}/rename) на
+# `probe/x` - собственно rename, не push - тоже породил событие `push` и
+# запустил job. Значит, ни порядок «сначала пуш, потом рено переименование»,
+# ни наоборот, не спасают - разница только в том, что ловит паттерн.
+#
+# Публикация - решение владельца (см. задачу), а первая раскладка кода при
+# уже готовых секретах - тот самый момент, когда его нельзя было принять за
+# него молча. Добавить `push: branches: ['xmine/**']` - однострочная правка;
+# владелец делает её сам, когда решит, что настало время первой публикации
+# (или каждого следующего push). До этого запуск - только вручную,
+# `workflow_dispatch`, и тоже по решению владельца.
+
+name: XMine - publish HuskSync
+
+on:
+  workflow_dispatch:
+
+# Публикация не должна идти в два потока: параллельные сборки означали бы
+# гонку за то, чей билд-номер снапшота окажется последним в maven-metadata.xml.
+concurrency:
+  group: xmine-publish-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  # Версия - настоящий Maven SNAPSHOT, а не неизменяемая координата вида
+  # <апстрим>-xmine.N (как в LibertyBans 1.2.0-M1-xmine.1 или CoreProtect
+  # 24.0-xmine.1). Причина: первый прогон стенда идёт сразу на форке, и правки
+  # почти наверняка потребуются не один раз. SNAPSHOT можно перезаливать по
+  # тому же адресу; неизменяемую версию - нет, под неё пришлось бы поднимать N
+  # на каждую мелкую правку конфигурации.
+  #
+  # Число "1" в xmine.1 фиксирует НОМЕР НАШЕГО ФОРКА правки поверх апстримной
+  # 4.0.0, а не билд снапшота - билды снапшота нумерует сам Reposilite
+  # (versioning/snapshot/buildNumber в maven-metadata.xml). Когда правка
+  # перестанет быть черновой, релизная версия задаётся уже без -SNAPSHOT
+  # отдельным решением владельца - это не автоматизировано специально
+  # (см. xmine-versioning: версия - решение в момент релиза, не число в файле).
+  XMINE_VERSION: 4.0.0-xmine.1-SNAPSHOT
+  MAVEN_GROUP_PATH: ru/xmine/thirdparty
+  MAVEN_ARTIFACT: husksync
+  # Раздел `third-party` закрыт авторизацией: там лежат чужие бинарники,
+  # которые нельзя раздавать публично (ADR-0011). Наш форк едет туда же - он
+  # берёт апстримный код и не является нашим плагином.
+  MAVEN_SECTION: third-party
+
+jobs:
+  publish:
+    # Форки самого форка не должны пытаться публиковать в наш Reposilite.
+    if: github.repository == 'XMineServer/HuskSync'
+    runs-on: ubuntu-latest
+
+    env:
+      XMINE_MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+      XMINE_MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+      XMINE_MAVEN_URL: https://maven.xmine.world/third-party
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Fail early without credentials
+        run: |
+          # Без учётки сборка дошла бы до конца (компиляция common + всех
+          # bukkit-версий, javadoc, shadowJar) и упала бы только на публикации.
+          # Дешевле проверить сразу.
+          set -eu
+          if [ -z "${XMINE_MAVEN_USERNAME:-}" ] || [ -z "${XMINE_MAVEN_PASSWORD:-}" ]; then
+            echo "::error::Secrets MAVEN_USERNAME / MAVEN_PASSWORD are not set"
+            exit 1
+          fi
+
+      - name: Test
+        # Только common: своя правка (подстановка env в config.yml) целиком там,
+        # и там же весь тестовый набор проекта (58 тестов на момент правки,
+        # без testcontainers и без Docker) - platform-модули (bukkit/fabric)
+        # тестов не имеют.
+        run: ./gradlew :common:test --stacktrace
+
+      - name: Build
+        # Нода тянет сборку Paper/Bukkit под 26.1.2 - именно ту версию
+        # зеркалирует сегодняшняя прод-координата husksync:4.0.0-26.1.2
+        # (см. XMineNode/plugins/common.yml). Остальные bukkit-модули
+        # (1.21.10, 1.21.11, 26.2) и fabric не публикуются - на проде их нет.
+        run: ./gradlew :bukkit:26.1.2:shadowJar --stacktrace
+
+      - name: Publish snapshot to Reposilite
+        # Не curl, в отличие от LibertyBans/CoreProtect: там версия неизменяемая
+        # и совпадает с именем файла один в один, а для SNAPSHOT сам Reposilite
+        # должен вести maven-metadata.xml (versioning/snapshot/timestamp и
+        # .../buildNumber) - без них XMineNode/build/fetch.py::resolve_maven не
+        # сможет собрать реальное имя файла husksync-4.0.0-xmine.1-<ts>-<N>.jar
+        # и упадёт с "maven-metadata.xml has no complete versioning/snapshot".
+        # Простой PUT jar-а по адресу версии эти метаданные не создаёт и не
+        # обновляет. Поэтому здесь настоящий `maven-publish` (публикация
+        # добавлена в bukkit/build.gradle, работает только для модуля 26.1.2)
+        # - Gradle сам запрашивает текущий maven-metadata.xml, считает
+        # следующий buildNumber и заливает и jar, и обновлённые метаданные.
+        run: |
+          ./gradlew :bukkit:26.1.2:publishXmineThirdPartyPublicationToXmineRepository \
+            -PxmineVersion="${XMINE_VERSION}" --stacktrace
+
+      - name: Verify metadata round-trip
+        # "Опубликовано" должно означать больше, чем "сервер ответил 2xx" -
+        # известный случай (known-issues.md) как раз про молчаливо
+        # перезаписанный third-party. Для SNAPSHOT sha256 незачем сверять: имя
+        # файла меняется при каждой публикации, совпадать с предыдущим он и не
+        # должен. Вместо этого читаем maven-metadata.xml обратно и проверяем,
+        # что buildNumber/timestamp на месте - то есть что именно наша
+        # публикация (а не старая, не полупустая) там лежит.
+        run: |
+          set -eu
+          BASE="${XMINE_MAVEN_URL}/${MAVEN_GROUP_PATH}/${MAVEN_ARTIFACT}/${XMINE_VERSION}"
+          curl --fail-with-body --silent --show-error \
+               --user "${XMINE_MAVEN_USERNAME}:${XMINE_MAVEN_PASSWORD}" \
+               -o /tmp/maven-metadata.xml "${BASE}/maven-metadata.xml"
+
+          TIMESTAMP="$(sed -n 's:.*<timestamp>\(.*\)</timestamp>.*:\1:p' /tmp/maven-metadata.xml)"
+          BUILD_NUMBER="$(sed -n 's:.*<buildNumber>\(.*\)</buildNumber>.*:\1:p' /tmp/maven-metadata.xml)"
+          if [ -z "$TIMESTAMP" ] || [ -z "$BUILD_NUMBER" ]; then
+            echo "::error::maven-metadata.xml has no complete versioning/snapshot - fetch.py on the node would fail the same way"
+            cat /tmp/maven-metadata.xml
+            exit 1
+          fi
+
+          JAR_NAME="${MAVEN_ARTIFACT}-${XMINE_VERSION%-SNAPSHOT}-${TIMESTAMP}-${BUILD_NUMBER}.jar"
+          {
+            echo "### Published"
+            echo '```'
+            echo "$(echo "${MAVEN_GROUP_PATH}" | tr '/' '.'):${MAVEN_ARTIFACT}:${XMINE_VERSION}"
+            echo "repo:     ${MAVEN_SECTION}"
+            echo "resolved: ${JAR_NAME}"
+            echo '```'
+            echo
+            echo "sha256 не публикуется: для SNAPSHOT имя файла меняется при"
+            echo "каждой публикации, пин по хешу в plugins/common.yml не применим"
+            echo "(см. fetch.py - для *-SNAPSHOT координат используется maven-metadata.xml,"
+            echo "а не прямой URL с sha256)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/bukkit/build.gradle
+++ b/bukkit/build.gradle
@@ -97,3 +97,64 @@ tasks {
         }
     }
 }
+
+// XMine start - публикация в свой Reposilite
+//
+// Этот build.gradle общий на все версии букита (1.21.10, 1.21.11, 26.2, 26.1.2 -
+// см. settings.gradle, buildFileName = '../build.gradle'), а нода тянет только
+// сборку под 26.1.2 (XMineNode/plugins/common.yml, координата
+// ru.xmine.thirdparty:husksync). Публиковать остальные версии незачем и не на чем
+// проверить - поэтому блок целиком под условием project.name == '26.1.2', а не в
+// корневом build.gradle, где такой развилки нет.
+//
+// Версия - настоящий maven-SNAPSHOT (xmine-publish.yml передаёт её через
+// -PxmineVersion), а не собственная неизменяемая координата вроде
+// LibertyBans/CoreProtect (<апстрим>-xmine.N): первый прогон стенда пойдёт на
+// форке и правки нужны будут не раз, а SNAPSHOT-версию можно перезаливать по тому
+// же адресу. Значение по умолчанию - для локального ./gradlew build без -P, чтобы
+// сборка не падала на конфигурации.
+if (project.name == '26.1.2') {
+    def xmineVersion = providers.gradleProperty('xmineVersion').getOrElse('0.0.0-xmine-local-SNAPSHOT')
+
+    publishing {
+        publications {
+            // Своя координата, не мешает апстримным mavenJavaBukkit_* публикациям
+            // (net.william278.husksync:husksync-bukkit) - у них нет настроенных
+            // repositories, поэтому publish-задачи для них даже не создаются
+            // (проверено: ./gradlew :bukkit:26.1.2:tasks --group publishing до этой
+            // правки показывает только publish/publishToMavenLocal без адреса).
+            xmineThirdParty(MavenPublication) {
+                groupId = 'ru.xmine.thirdparty'
+                artifactId = 'husksync'
+                version = xmineVersion
+
+                artifact(shadowJar) {
+                    // Задача уже собирает classifier '' (см. корневой build.gradle,
+                    // subprojects.shadowJar), но без явного null Gradle всё равно
+                    // может унаследовать классификатор из имени задачи - обнуляем,
+                    // чтобы в координате не оказалось лишнего суффикса.
+                    classifier = null
+                }
+            }
+        }
+
+        repositories {
+            maven {
+                name = 'xmine'
+                // third-party - тот самый закрытый раздел, откуда фактически берёт
+                // файл XMineNode (repo: third-party в plugins/common.yml).
+                url = uri(providers.environmentVariable('XMINE_MAVEN_URL')
+                        .getOrElse('https://maven.xmine.world/third-party'))
+                credentials {
+                    username = providers.environmentVariable('XMINE_MAVEN_USERNAME').orNull
+                    password = providers.environmentVariable('XMINE_MAVEN_PASSWORD').orNull
+                }
+            }
+        }
+    }
+
+    tasks.named('publishXmineThirdPartyPublicationToXmineRepository') {
+        dependsOn(shadowJar)
+    }
+}
+// XMine end - публикация в свой Reposilite

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -17,6 +17,13 @@ dependencies {
 
     compileOnlyApi 'net.william278.toilet:toilet-common:1.1.2'
 
+    // XMine start - подстановка переменных среды в конфиге
+    // Уже на рантайме: configlib-yaml тянет его как runtime-зависимость (2.7), а fabric
+    // дополнительно include'ит 3.0.1. Здесь только компиляция — версия артефакта не меняется,
+    // и берётся младшая из двух, чтобы нельзя было случайно использовать API, которого в ней нет.
+    compileOnly 'org.snakeyaml:snakeyaml-engine:2.7'
+    // XMine end - подстановка переменных среды в конфиге
+
     compileOnly 'net.william278.uniform:uniform-common:1.3.9'
     compileOnly 'com.mojang:brigadier:1.1.8'
     compileOnly 'org.projectlombok:lombok:1.18.42'
@@ -39,7 +46,11 @@ dependencies {
     testImplementation 'com.google.guava:guava:33.6.0-jre'
     testImplementation 'com.github.plan-player-analytics:Plan:5.6.2965'
     testImplementation 'net.kyori:adventure-text-minimessage:4.25.0'
+    // XMine - Settings ссылается на PluginCommand, а тот на uniform: без него класс конфига
+    // не загрузить в тесте. В main зависимость по-прежнему compileOnly, в jar не попадает.
+    testRuntimeOnly 'net.william278.uniform:uniform-common:1.3.9'
     testCompileOnly 'de.exlll:configlib-yaml:4.8.1'
+    testCompileOnly 'org.snakeyaml:snakeyaml-engine:2.7' // XMine - подстановка переменных среды в конфиге
     testCompileOnly 'org.jetbrains:annotations:26.1.0'
 
     annotationProcessor 'org.projectlombok:lombok:1.18.42'

--- a/common/src/main/java/net/william278/husksync/config/ConfigProvider.java
+++ b/common/src/main/java/net/william278/husksync/config/ConfigProvider.java
@@ -27,6 +27,8 @@ import de.exlll.configlib.YamlConfigurations;
 import net.william278.husksync.HuskSync;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.ByteArrayInputStream; // XMine - подстановка переменных среды в конфиге
+import java.io.IOException; // XMine - подстановка переменных среды в конфиге
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -68,11 +70,61 @@ public interface ConfigProvider {
      * @since 1.0
      */
     default void loadSettings() {
-        setSettings(YamlConfigurations.update(
+        setSettings(loadWithEnvironment( // XMine - подстановка переменных среды в конфиге
                 getConfigDirectory().resolve("config.yml"),
                 Settings.class,
                 YAML_CONFIGURATION_PROPERTIES.header(Settings.CONFIG_HEADER).build()
         ));
+    }
+
+    // XMine start - подстановка переменных среды в конфиге
+    /**
+     * Loads a configuration file, expanding the {@code ${NAME}} environment variable references in
+     * it - see {@link EnvironmentYaml} for how, and {@link EnvironmentSubstitutor} for why the
+     * syntax is what it is.
+     * <p>
+     * The path splits in two, and which branch is taken depends only on whether the file holds any
+     * references at all:
+     * <ul>
+     *     <li><b>It does not.</b> {@link YamlConfigurations#update} runs exactly as upstream calls
+     *     it: the file is read, then written back with any keys new to this version merged in.</li>
+     *     <li><b>It does.</b> The file is read through the expansion and <em>not</em> written back.
+     *     What the plugin holds after loading is the resolved value, so a write-back would replace
+     *     {@code password: "${DATABASE_PASSWORD}"} with the database password in plain text, in a
+     *     file that is otherwise safe to read - defeating the entire point. Losing the merge costs
+     *     XMine nothing: these configs ship inside the node image and are laid out afresh on every
+     *     start, so new keys arrive with the image, not at runtime.</li>
+     * </ul>
+     * A file that does not exist yet is created from the defaults either way; without that the
+     * plugin does not come up at all on a clean install.
+     *
+     * @param file       the configuration file
+     * @param type       the configuration class
+     * @param properties the ConfigLib properties to read it with
+     * @param <T>        the configuration type
+     * @return the loaded configuration
+     */
+    @NotNull
+    private static <T> T loadWithEnvironment(@NotNull Path file, @NotNull Class<T> type,
+                                             @NotNull YamlConfigurationProperties properties) {
+        if (Files.exists(file)) {
+            try {
+                final String expanded = EnvironmentYaml.expand(
+                        Files.readString(file, properties.getCharset()), System::getenv
+                );
+                if (expanded != null) {
+                    return new YamlConfigurationStore<>(type, properties).read(
+                            new ByteArrayInputStream(expanded.getBytes(properties.getCharset()))
+                    );
+                }
+            } catch (IOException e) {
+                // Fall through to upstream's path, which reports an unreadable file its own way.
+                // Note what does not happen here: nothing about the file's content is logged,
+                // because that content is where the secrets are.
+            }
+        }
+        return YamlConfigurations.update(file, type, properties);
+        // XMine end - подстановка переменных среды в конфиге
     }
 
     /**

--- a/common/src/main/java/net/william278/husksync/config/EnvironmentSubstitutor.java
+++ b/common/src/main/java/net/william278/husksync/config/EnvironmentSubstitutor.java
@@ -1,0 +1,215 @@
+/*
+ * This file is part of HuskSync, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.husksync.config;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+
+// XMine start - подстановка переменных среды в конфиге
+/**
+ * Expands environment variable references such as {@code ${DB_HOST}} inside configuration values.
+ * <p>
+ * This is a port of {@code io.papermc.paper.configuration.EnvironmentSubstitutor} from the XMine
+ * fork of Paper, character for character in behaviour. It has to be a port rather than a call:
+ * the core hooks substitution into {@code org.bukkit.configuration.file.YamlConfiguration}
+ * (nothing else), HuskSync reads its config through ConfigLib and SnakeYAML Engine, and the
+ * {@code common} module compiles without any server API at all. Two implementations of one syntax
+ * is a cost accepted deliberately - the alternative is an operator who has to remember which
+ * plugin takes which spelling.
+ *
+ * <h2>Syntax</h2>
+ * <ul>
+ *     <li>{@code ${NAME}} - replaced by the value of the environment variable {@code NAME}.
+ *     If the variable is <em>not set</em>, the reference is left in place verbatim. If it is
+ *     set but empty, it expands to the empty string.</li>
+ *     <li>{@code ${NAME:-fallback}} - replaced by the value of {@code NAME} when it is set and
+ *     non-empty, and by {@code fallback} otherwise. This mirrors the POSIX shell operator of the
+ *     same name, including its treatment of an empty value as "not set". The fallback text is
+ *     itself expanded, so {@code ${A:-${B:-none}}} works.</li>
+ *     <li>{@code $${NAME}} - an escape: expands to the literal text {@code ${NAME}} and the
+ *     variable is never looked up.</li>
+ * </ul>
+ *
+ * <h2>Why these rules</h2>
+ * Configuration files that exist today were written without any knowledge of this feature, and
+ * silently corrupting one is far worse than failing to expand a reference somebody wanted
+ * expanded: a missed expansion is visible in the config and trivially diagnosed, a wrong one
+ * shows up as a plugin misbehaving weeks later. Every ambiguous case is therefore resolved in
+ * favour of leaving the text alone:
+ * <ul>
+ *     <li><b>Names are upper case only</b> ({@code [A-Z_][A-Z0-9_]*}). Environment variables are
+ *     upper case by universal convention (POSIX, Docker, systemd, 12-factor); placeholders that
+ *     plugins define for themselves are overwhelmingly lower case ({@code ${player}},
+ *     {@code ${world}}), so restricting the charset costs nothing real and removes most of the
+ *     collision surface at a stroke.</li>
+ *     <li><b>An unset variable is left as written</b>, rather than expanding to the empty string
+ *     or throwing. An empty string turns "the operator forgot to set DATABASE_PASSWORD" into a
+ *     confusing authentication failure later on; throwing would stop the whole plugin over one
+ *     unrelated placeholder. Leaving {@code ${DATABASE_PASSWORD}} in place makes the mistake
+ *     self-describing. Use {@code ${NAME:-}} to ask for an empty string explicitly.</li>
+ *     <li><b>{@code $$} is the escape</b>, matching Docker Compose, rather than a backslash.
+ *     A backslash would have to survive YAML's own escaping inside double-quoted scalars, which
+ *     is exactly the kind of rule nobody gets right the first time.</li>
+ *     <li><b>Substituted values are never rescanned.</b> If {@code A=${B}} then {@code ${A}}
+ *     expands to the four characters {@code ${B}}, not to the value of {@code B}. This rules out
+ *     both expansion loops and an injection where the content of one variable reaches into
+ *     another.</li>
+ * </ul>
+ *
+ * <h2>Logging</h2>
+ * This class never logs, and never places a variable's value into an exception message. Secrets
+ * are the main reason to reach for this feature at all, so nothing here may leak one.
+ *
+ * @see EnvironmentYaml
+ */
+public final class EnvironmentSubstitutor {
+
+    private static final Pattern VARIABLE_NAME = Pattern.compile("[A-Z_][A-Z0-9_]*");
+
+    /**
+     * Guards against a fallback chain such as {@code ${A:-${A:-${A:-...}}}} nested deeply enough
+     * to matter. Real configurations never come close.
+     */
+    private static final int MAX_DEPTH = 16;
+
+    private EnvironmentSubstitutor() {
+    }
+
+    /**
+     * Expands every environment variable reference in the given text.
+     *
+     * @param text        the raw configuration text
+     * @param environment lookup for variable values, normally {@code System::getenv}; it must
+     *                    return {@code null} for a variable that is not set
+     * @return the expanded text, or {@code null} if the text contains nothing to expand - callers
+     * use this to keep the original scalar and skip any bookkeeping
+     */
+    @Nullable
+    public static String substitute(@NotNull String text, @NotNull UnaryOperator<String> environment) {
+        return substitute(text, environment, 0);
+    }
+
+    @Nullable
+    private static String substitute(@NotNull String text, @NotNull UnaryOperator<String> environment, int depth) {
+        if (depth > MAX_DEPTH || text.indexOf('$') < 0) {
+            return null; // fast path: the overwhelming majority of configuration values
+        }
+
+        final int length = text.length();
+        StringBuilder result = null;
+        int index = 0;
+        while (index < length) {
+            final char current = text.charAt(index);
+            if (current != '$') {
+                if (result != null) {
+                    result.append(current);
+                }
+                index++;
+                continue;
+            }
+
+            // "$${NAME}" -> literal "${NAME}", with the body copied over untouched.
+            if (index + 2 < length && text.charAt(index + 1) == '$' && text.charAt(index + 2) == '{') {
+                final int close = matchingBrace(text, index + 2);
+                if (close >= 0) {
+                    if (result == null) {
+                        result = new StringBuilder(length + 16).append(text, 0, index);
+                    }
+                    result.append(text, index + 1, close + 1);
+                    index = close + 1;
+                    continue;
+                }
+            }
+
+            if (index + 1 < length && text.charAt(index + 1) == '{') {
+                final int close = matchingBrace(text, index + 1);
+                if (close >= 0) {
+                    final String replacement = resolve(text.substring(index + 2, close), environment, depth);
+                    if (replacement != null) {
+                        if (result == null) {
+                            result = new StringBuilder(length + 16).append(text, 0, index);
+                        }
+                        result.append(replacement);
+                        index = close + 1;
+                        continue;
+                    }
+                }
+            }
+
+            // A lone '$', an unterminated '${', a lower-case name, an unset variable: leave it be.
+            if (result != null) {
+                result.append(current);
+            }
+            index++;
+        }
+
+        return result == null ? null : result.toString();
+    }
+
+    /**
+     * Resolves the body of a single {@code ${...}} reference.
+     *
+     * @return the replacement text, or {@code null} to leave the reference in place verbatim
+     */
+    @Nullable
+    private static String resolve(@NotNull String body, @NotNull UnaryOperator<String> environment, int depth) {
+        final int separator = body.indexOf(":-");
+        final String name = separator < 0 ? body : body.substring(0, separator);
+        if (!VARIABLE_NAME.matcher(name).matches()) {
+            return null;
+        }
+
+        final String value = environment.apply(name);
+        if (separator < 0) {
+            return value; // null - not set - leaves "${NAME}" untouched
+        }
+        if (value != null && !value.isEmpty()) {
+            return value;
+        }
+
+        final String fallback = body.substring(separator + 2);
+        final String expanded = substitute(fallback, environment, depth + 1);
+        return expanded != null ? expanded : fallback;
+    }
+
+    /**
+     * Finds the {@code '}'} matching the {@code '{'} at {@code open}, counting nested braces so
+     * that {@code ${A:-${B}}} and {@code ${A:-{literal}}} both parse.
+     *
+     * @return the index of the closing brace, or {@code -1} if the reference is unterminated
+     */
+    private static int matchingBrace(@NotNull String text, int open) {
+        int depth = 0;
+        for (int index = open; index < text.length(); index++) {
+            final char current = text.charAt(index);
+            if (current == '{') {
+                depth++;
+            } else if (current == '}' && --depth == 0) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
+}
+// XMine end - подстановка переменных среды в конфиге

--- a/common/src/main/java/net/william278/husksync/config/EnvironmentYaml.java
+++ b/common/src/main/java/net/william278/husksync/config/EnvironmentYaml.java
@@ -1,0 +1,341 @@
+/*
+ * This file is part of HuskSync, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.husksync.config;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.api.lowlevel.Compose;
+import org.snakeyaml.engine.v2.api.lowlevel.Present;
+import org.snakeyaml.engine.v2.api.lowlevel.Serialize;
+import org.snakeyaml.engine.v2.common.FlowStyle;
+import org.snakeyaml.engine.v2.common.ScalarStyle;
+import org.snakeyaml.engine.v2.nodes.MappingNode;
+import org.snakeyaml.engine.v2.nodes.Node;
+import org.snakeyaml.engine.v2.nodes.NodeTuple;
+import org.snakeyaml.engine.v2.nodes.ScalarNode;
+import org.snakeyaml.engine.v2.nodes.SequenceNode;
+import org.snakeyaml.engine.v2.nodes.Tag;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+
+// XMine start - подстановка переменных среды в конфиге
+/**
+ * Rewrites a YAML document, expanding the environment variable references in its scalars.
+ *
+ * <h2>Why the substitution is not left to SnakeYAML</h2>
+ * SnakeYAML Engine - the parser ConfigLib uses - ships variable substitution of its own:
+ * {@link org.snakeyaml.engine.v2.env.EnvConfig} plus {@code StandardConstructor.ConstructEnv},
+ * driven by an <em>implicit</em> resolver ({@code JsonScalarResolver} maps any plain scalar
+ * matching {@code ENV_FORMAT} to {@code Tag.ENV_TAG}). Worth stating plainly, because the
+ * opposite is true of the older {@code org.yaml.snakeyaml} library: <b>no {@code !ENV} tag is
+ * needed here</b>. That objection does not apply to this codebase.
+ * <p>
+ * It still cannot be used, for two independent reasons.
+ * <p>
+ * <b>ConfigLib gives it nowhere to plug in.</b> {@code YamlConfigurationStore} builds its loader
+ * once, in a {@code private static final} field, from {@code LoadSettings.builder().build()} - no
+ * {@code EnvConfig} - and its constructor then <em>clears</em> {@code tagConstructors} and
+ * re-registers only NULL/BOOL/STR/SEQ/MAP/INT/FLOAT. {@code YamlConfigurationProperties} exposes
+ * no hook onto any of that. So a scalar carrying {@code Tag.ENV_TAG} does not get substituted by
+ * ConfigLib; it fails to load at all, with "could not determine a constructor for the tag
+ * !ENV_VARIABLE". (That is a pre-existing trap, not one this class introduces: an unquoted
+ * {@code port: ${DATABASE_PORT}} breaks HuskSync's config loading today.)
+ * <p>
+ * <b>Its semantics are not ours.</b> The XMine fork of Paper expands {@code ${NAME}} inside every
+ * Bukkit YAML configuration, and an operator writes configs for a dozen plugins; one syntax has
+ * to mean one thing. {@code ENV_FORMAT} is anchored, so it only ever matches a scalar that is
+ * <em>entirely</em> a placeholder - {@code jdbc://${HOST}/db} would be a literal; its name group
+ * is {@code \w+}, so a lower-case {@code ${player}} counts as a variable; its default group is
+ * {@code \w+} too, so {@code ${HOST:-db.internal}} silently is not a placeholder at all because
+ * of the dot; an unset variable becomes the empty string; and {@code $${NAME}} is not an escape.
+ * Every one of those differs from {@link EnvironmentSubstitutor}, and none of them can be fixed
+ * through {@code EnvConfig}, which is only consulted <em>after</em> the resolver has already
+ * decided what is a placeholder and what its parts are.
+ * <p>
+ * What is used from SnakeYAML Engine instead is its document model: {@link Compose} parses,
+ * {@link Serialize} and {@link Present} write back. Substitution happens on the composed node
+ * tree, exactly as it does in the core, and for the same reason: an expanded value can then
+ * neither change the structure of the document nor turn a parse error into a place where a
+ * secret could be printed. A password containing a quote, a colon or a newline is re-emitted
+ * correctly quoted, because the emitter quotes it; a textual search-and-replace over the file
+ * would produce a broken document, or worse, a valid one with a different shape.
+ *
+ * <h2>Types</h2>
+ * An unquoted {@code port: ${DATABASE_PORT}} has to end up an integer, or ConfigLib rejects it
+ * for an {@code int} field. The tag of a substituted scalar is therefore re-resolved from the
+ * expanded text, but only over the narrow whitelist in {@link #implicitTag(String)} - the values
+ * that survive a YAML round trip unchanged. A quoted reference stays a string, exactly as a
+ * quoted literal would.
+ */
+public final class EnvironmentYaml {
+
+    /**
+     * A decimal integer whose {@code toString} is byte-for-byte what was read. Anything else -
+     * {@code 0755}, {@code 1_000}, {@code 0x1F}, {@code -0} - is deliberately left as a string:
+     * YAML 1.1 would turn {@code 0755} into 493, and a value the operator never wrote would then
+     * be what the plugin runs on.
+     */
+    private static final Pattern CANONICAL_INT = Pattern.compile("0|-?[1-9][0-9]*");
+    private static final Pattern CANONICAL_FLOAT = Pattern.compile("-?(?:0|[1-9][0-9]*)\\.[0-9]+");
+
+    /**
+     * Mirrors the settings ConfigLib itself loads and dumps with, so that a document which passes
+     * through this class parses into exactly what it would have parsed into otherwise.
+     */
+    private static final LoadSettings LOAD_SETTINGS = LoadSettings.builder().build();
+    private static final DumpSettings DUMP_SETTINGS = DumpSettings.builder()
+            .setDefaultFlowStyle(FlowStyle.BLOCK)
+            .setIndent(2)
+            .build();
+
+    private EnvironmentYaml() {
+    }
+
+    /**
+     * Expands the environment variable references in a YAML document.
+     * <p>
+     * Comments are not preserved: the caller is expected to use the result only to read values
+     * from, never to write it back over the operator's file. Writing an expanded document back
+     * would put the database password on disk in plain text, which is the one thing this whole
+     * mechanism exists to avoid.
+     *
+     * @param yaml        the document text
+     * @param environment lookup for variable values, normally {@code System::getenv}
+     * @return the rewritten document, or {@code null} when the document holds no references at
+     * all and the caller should just read the original file
+     */
+    @Nullable
+    public static String expand(@NotNull String yaml, @NotNull UnaryOperator<String> environment) {
+        // No '$' anywhere means no placeholder and no ENV-tagged scalar, so there is nothing to
+        // rewrite and nothing to normalise. Taking the original path in that case keeps the
+        // behaviour of a config without references identical to upstream's, comments and all.
+        if (yaml.indexOf('$') < 0) {
+            return null;
+        }
+
+        final Optional<Node> root = new Compose(LOAD_SETTINGS).composeString(yaml);
+        if (root.isEmpty()) {
+            return null;
+        }
+
+        final Node original = root.get();
+        final Node substituted = substitute(original, environment, new IdentityHashMap<>());
+        final Node document = substituted != null ? substituted : original;
+        return new Present(DUMP_SETTINGS).emitToString(
+                new Serialize(DUMP_SETTINGS).serializeOne(document).iterator()
+        );
+    }
+
+    /**
+     * Visits a node, rewriting the scalars beneath it.
+     *
+     * @param node        the node to visit
+     * @param environment lookup for variable values
+     * @param visited     nodes already visited, so that a YAML alias follows its anchor and a
+     *                    recursive document terminates. {@code Node} compares by identity, its
+     *                    {@code equals} being final, so this really is an identity map
+     * @return a node that must take {@code node}'s place in its parent, or {@code null} when the
+     * parent should keep the node it has
+     */
+    @Nullable
+    private static Node substitute(@NotNull Node node, @NotNull UnaryOperator<String> environment,
+                                   @NotNull Map<Node, Node> visited) {
+        final Node seen = visited.get(node);
+        if (seen != null) {
+            return seen == node ? null : seen;
+        }
+        visited.put(node, node);
+
+        if (node instanceof MappingNode mapping) {
+            final List<NodeTuple> tuples = mapping.getValue();
+            List<NodeTuple> rebuilt = null;
+            for (int i = 0; i < tuples.size(); i++) {
+                final NodeTuple tuple = tuples.get(i);
+                // A key is a path segment, never a value: substituting one would move a setting
+                // somewhere else behind the plugin's back. It is still visited, because a key
+                // that merely looks like a placeholder carries Tag.ENV_TAG and would otherwise
+                // stop ConfigLib from constructing the document at all.
+                final Node key = normaliseKey(tuple.getKeyNode());
+                final Node value = substitute(tuple.getValueNode(), environment, visited);
+                if (key != null || value != null) {
+                    if (rebuilt == null) {
+                        rebuilt = new ArrayList<>(tuples);
+                    }
+                    rebuilt.set(i, new NodeTuple(
+                            key != null ? key : tuple.getKeyNode(),
+                            value != null ? value : tuple.getValueNode()
+                    ));
+                }
+            }
+            if (rebuilt == null) {
+                return null;
+            }
+            final Node replacement = new MappingNode(mapping.getTag(), rebuilt, mapping.getFlowStyle());
+            visited.put(mapping, replacement);
+            return replacement;
+        }
+
+        if (node instanceof SequenceNode sequence) {
+            final List<Node> values = sequence.getValue();
+            List<Node> rebuilt = null;
+            for (int i = 0; i < values.size(); i++) {
+                final Node replacement = substitute(values.get(i), environment, visited);
+                if (replacement != null) {
+                    if (rebuilt == null) {
+                        rebuilt = new ArrayList<>(values);
+                    }
+                    rebuilt.set(i, replacement);
+                }
+            }
+            if (rebuilt == null) {
+                return null;
+            }
+            final Node replacement = new SequenceNode(sequence.getTag(), rebuilt, sequence.getFlowStyle());
+            visited.put(sequence, replacement);
+            return replacement;
+        }
+
+        if (!(node instanceof ScalarNode scalar)) {
+            return null;
+        }
+
+        final String expanded = EnvironmentSubstitutor.substitute(scalar.getValue(), environment);
+        final Node replacement;
+        if (expanded == null) {
+            // Nothing was expanded. A reference left verbatim - an unset variable, a lower-case
+            // name - still has to lose Tag.ENV_TAG, or the document will not construct.
+            replacement = detag(scalar);
+        } else {
+            // An unquoted "${DATABASE_PORT}" should behave like the number it expands to. A quoted
+            // one stays a string, exactly as a quoted literal would have.
+            final Tag tag = scalar.isPlain() && isPlainText(scalar.getTag())
+                    ? implicitTag(expanded)
+                    : Tag.STR;
+            replacement = new ScalarNode(tag, expanded, styleFor(tag, scalar));
+        }
+        if (replacement != null) {
+            visited.put(scalar, replacement);
+        }
+        return replacement;
+    }
+
+    /**
+     * Strips {@code Tag.ENV_TAG} off a mapping key that happens to look like a placeholder. Its
+     * text is untouched.
+     *
+     * @param key the key node
+     * @return the replacement key, or {@code null} to keep the one there is
+     */
+    @Nullable
+    private static Node normaliseKey(@NotNull Node key) {
+        return key instanceof ScalarNode scalar ? detag(scalar) : null;
+    }
+
+    /**
+     * Re-tags a scalar that the resolver read as a placeholder but that was left unexpanded, so
+     * that ConfigLib - which knows no such tag - can construct it as the plain string it is.
+     *
+     * @param scalar the scalar
+     * @return the replacement scalar, or {@code null} to keep the one there is
+     */
+    @Nullable
+    private static Node detag(@NotNull ScalarNode scalar) {
+        if (!Tag.ENV_TAG.equals(scalar.getTag())) {
+            return null;
+        }
+        return new ScalarNode(Tag.STR, scalar.getValue(), ScalarStyle.DOUBLE_QUOTED);
+    }
+
+    /**
+     * Whether a scalar's tag marks it as text the resolver had no better guess for - the two
+     * tags a {@code ${...}} reference can end up with.
+     *
+     * @param tag the tag the scalar was composed with
+     * @return whether an expansion of it may be re-typed
+     */
+    private static boolean isPlainText(@NotNull Tag tag) {
+        return Tag.STR.equals(tag) || Tag.ENV_TAG.equals(tag);
+    }
+
+    /**
+     * Resolves the implicit YAML tag of an expanded scalar, but only where the value survives a
+     * round trip unchanged. Everything else stays a string rather than hand the plugin a value
+     * the operator never wrote.
+     *
+     * @param value the expanded scalar text
+     * @return the tag to give the scalar
+     */
+    @NotNull
+    private static Tag implicitTag(@NotNull String value) {
+        if (value.isEmpty()) {
+            return Tag.STR; // an empty expansion is an empty string, not null
+        }
+        if (CANONICAL_INT.matcher(value).matches()) {
+            return Tag.INT;
+        }
+        if (value.equals("true") || value.equals("false")) {
+            return Tag.BOOL; // not "yes"/"on": those are not booleans to a YAML 1.2 parser anyway
+        }
+        if (CANONICAL_FLOAT.matcher(value).matches()) {
+            try {
+                if (Double.toString(Double.parseDouble(value)).equals(value)) {
+                    return Tag.FLOAT;
+                }
+            } catch (NumberFormatException ignored) {
+                // fall through to Tag.STR
+            }
+        }
+        // Everything else - timestamps, sexagesimals, "~", "yes" - stays a string on purpose:
+        // the whitelist above is exactly the set of values that survive a round trip unchanged.
+        return Tag.STR;
+    }
+
+    /**
+     * Picks the style the expanded scalar is written in. A number or a boolean has to go out
+     * unquoted to be read back as one; text is always quoted, so that a password made entirely
+     * of digits, or of a {@code #}, or of a leading {@code *}, cannot come back as something
+     * else.
+     *
+     * @param tag      the tag the scalar will carry
+     * @param original the scalar being replaced
+     * @return the style to emit it in
+     */
+    @NotNull
+    private static ScalarStyle styleFor(@NotNull Tag tag, @NotNull ScalarNode original) {
+        if (!Tag.STR.equals(tag)) {
+            return ScalarStyle.PLAIN;
+        }
+        // LITERAL and FOLDED carry newlines meaningfully; anything else is safe to quote.
+        return original.getScalarStyle() == ScalarStyle.LITERAL
+                || original.getScalarStyle() == ScalarStyle.FOLDED
+                ? original.getScalarStyle()
+                : ScalarStyle.DOUBLE_QUOTED;
+    }
+
+}
+// XMine end - подстановка переменных среды в конфиге

--- a/common/src/test/java/net/william278/husksync/config/EnvironmentSubstitutionTests.java
+++ b/common/src/test/java/net/william278/husksync/config/EnvironmentSubstitutionTests.java
@@ -1,0 +1,226 @@
+/*
+ * This file is part of HuskSync, licensed under the Apache License 2.0.
+ *
+ *  Copyright (c) William278 <will27528@gmail.com>
+ *  Copyright (c) contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package net.william278.husksync.config;
+
+import de.exlll.configlib.NameFormatters;
+import de.exlll.configlib.YamlConfigurationProperties;
+import de.exlll.configlib.YamlConfigurationStore;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// XMine start - подстановка переменных среды в конфиге
+@DisplayName("Environment Substitution Tests")
+public class EnvironmentSubstitutionTests {
+
+    /**
+     * A stand-in for the process environment. {@code DATABASE_EMPTY} is set to the empty string on
+     * purpose - "set but empty" and "not set" are different cases and both are asserted below.
+     */
+    private static final Map<String, String> ENVIRONMENT = Map.of(
+            "DATABASE_HOST", "mariadb.internal",
+            "DATABASE_PORT", "3307",
+            "DATABASE_PASSWORD", "s3cr3t: \"quoted\" #and hashed",
+            "DATABASE_EMPTY", "",
+            "DATABASE_INDIRECT", "${DATABASE_HOST}"
+    );
+
+    private static final UnaryOperator<String> ENV = ENVIRONMENT::get;
+
+    // The scalar-level syntax: everything EnvironmentSubstitutor promises, and nothing else.
+
+    @ParameterizedTest(name = "{2}")
+    @DisplayName("Test Scalar Substitution")
+    @MethodSource("provideScalars")
+    public void testScalarSubstitution(@NotNull String template, @Nullable String expected,
+                                       @SuppressWarnings("unused") @NotNull String description) {
+        assertEquals(expected, EnvironmentSubstitutor.substitute(template, ENV));
+    }
+
+    @NotNull
+    private static Stream<Arguments> provideScalars() {
+        return Stream.of(
+                Arguments.of("${DATABASE_HOST}", "mariadb.internal",
+                        "A set variable is expanded"),
+                Arguments.of("jdbc:mariadb://${DATABASE_HOST}:${DATABASE_PORT}/husksync",
+                        "jdbc:mariadb://mariadb.internal:3307/husksync",
+                        "References are expanded inside a larger string"),
+                Arguments.of("${DATABASE_EMPTY}", "",
+                        "A variable set to the empty string expands to the empty string"),
+
+                Arguments.of("${DATABASE_SCHEMA:-husksync}", "husksync",
+                        "An unset variable falls back to its default"),
+                Arguments.of("${DATABASE_EMPTY:-husksync}", "husksync",
+                        "An empty variable falls back to its default, as in the POSIX shell"),
+                Arguments.of("${DATABASE_HOST:-localhost}", "mariadb.internal",
+                        "A set variable wins over its default"),
+                Arguments.of("${DATABASE_SCHEMA:-}", "",
+                        "An empty default is how one asks for the empty string"),
+                Arguments.of("${A_MISSING:-${DATABASE_HOST}}", "mariadb.internal",
+                        "A default is itself expanded"),
+                Arguments.of("${A_MISSING:-db.internal}", "db.internal",
+                        "A default may hold characters outside [A-Za-z0-9_]"),
+
+                Arguments.of("$${DATABASE_HOST}", "${DATABASE_HOST}",
+                        "$$ escapes a reference, which is then never looked up"),
+                Arguments.of("$${DATABASE_MISSING}", "${DATABASE_MISSING}",
+                        "The escape does not care whether the variable exists"),
+
+                Arguments.of("${DATABASE_MISSING}", null,
+                        "An unset variable is left in the text verbatim"),
+                Arguments.of("host is ${DATABASE_MISSING}", null,
+                        "An unset variable leaves the whole scalar alone"),
+
+                Arguments.of("${database_host}", null,
+                        "A lower-case name is not a variable"),
+                Arguments.of("${Database_Host}", null,
+                        "Nor is a mixed-case one"),
+                Arguments.of("${0DATABASE}", null,
+                        "Nor is one starting with a digit"),
+                Arguments.of("${player}", null,
+                        "Which is what keeps a plugin's own placeholders intact"),
+
+                Arguments.of("${DATABASE_INDIRECT}", "${DATABASE_HOST}",
+                        "An expanded value is never rescanned"),
+                Arguments.of("plain text", null,
+                        "Text without a reference is left alone"),
+                Arguments.of("$5.00 ${", null,
+                        "A lone $ and an unterminated ${ are left alone")
+        );
+    }
+
+    // The document level: what the plugin actually ends up loading.
+
+    @Test
+    @DisplayName("Test Document Substitution Keeps Types")
+    public void testDocumentSubstitutionKeepsTypes() {
+        final Map<String, Object> loaded = expandAndParse("""
+                database:
+                  host: "${DATABASE_HOST}"
+                  port: ${DATABASE_PORT}
+                  password: "${DATABASE_PASSWORD}"
+                """);
+        final Object database = loaded.get("database");
+        assertInstanceOf(Map.class, database);
+
+        final Map<?, ?> credentials = (Map<?, ?>) database;
+        assertEquals("mariadb.internal", credentials.get("host"));
+        assertEquals(3307, ((Number) credentials.get("port")).intValue(),
+                "An unquoted reference has to come back as the number it expanded to");
+        assertEquals(ENVIRONMENT.get("DATABASE_PASSWORD"), credentials.get("password"),
+                "A password full of YAML metacharacters has to survive being re-emitted");
+    }
+
+    @Test
+    @DisplayName("Test Unset Variable Still Parses")
+    public void testUnsetVariableStillParses() {
+        // The reference stays in the text, so the operator sees the mistake in the config rather
+        // than as a refused connection later. It must not stop the document from loading, and it
+        // must not carry SnakeYAML's !ENV_VARIABLE tag any further - ConfigLib cannot construct it.
+        final Map<String, Object> loaded = expandAndParse("""
+                database:
+                  host: ${DATABASE_MISSING}
+                  port: 3306
+                """);
+        final Map<?, ?> credentials = (Map<?, ?>) loaded.get("database");
+        assertEquals("${DATABASE_MISSING}", credentials.get("host"));
+        assertEquals(3306, ((Number) credentials.get("port")).intValue());
+    }
+
+    @Test
+    @DisplayName("Test Keys And Lists Are Handled")
+    public void testKeysAndListsAreHandled() {
+        final Map<String, Object> loaded = expandAndParse("""
+                hosts:
+                  - "${DATABASE_HOST}"
+                  - "${DATABASE_MISSING}"
+                ${DATABASE_HOST}: key
+                """);
+        assertEquals(java.util.List.of("mariadb.internal", "${DATABASE_MISSING}"), loaded.get("hosts"));
+        assertEquals("key", loaded.get("${DATABASE_HOST}"),
+                "A key is a path segment, so it is never substituted");
+    }
+
+    @Test
+    @DisplayName("Test Document Without References Is Left Alone")
+    public void testDocumentWithoutReferencesIsLeftAlone() {
+        assertNull(EnvironmentYaml.expand("database:\n  host: localhost\n", ENV),
+                "A config with nothing to expand must take the untouched upstream path");
+    }
+
+    @Test
+    @DisplayName("Test Substituted Config Loads Through ConfigLib")
+    public void testSubstitutedConfigLoadsThroughConfigLib() {
+        final String expanded = EnvironmentYaml.expand("""
+                database:
+                  type: MARIADB
+                  credentials:
+                    host: "${DATABASE_HOST}"
+                    port: ${DATABASE_PORT}
+                    database: husksync
+                    username: "${DATABASE_USER:-plugins}"
+                    password: "${DATABASE_PASSWORD}"
+                """, ENV);
+        assertNotNull(expanded);
+
+        final YamlConfigurationProperties properties = YamlConfigurationProperties.newBuilder()
+                .charset(StandardCharsets.UTF_8)
+                .setNameFormatter(NameFormatters.LOWER_UNDERSCORE)
+                .build();
+        final Settings settings = new YamlConfigurationStore<>(Settings.class, properties)
+                .read(new ByteArrayInputStream(expanded.getBytes(StandardCharsets.UTF_8)));
+
+        final Settings.DatabaseSettings.DatabaseCredentials credentials = settings.getDatabase().getCredentials();
+        assertEquals("mariadb.internal", credentials.getHost());
+        assertEquals(3307, credentials.getPort(), "An int field is only satisfied by a real integer");
+        assertEquals("plugins", credentials.getUsername());
+        assertEquals(ENVIRONMENT.get("DATABASE_PASSWORD"), credentials.getPassword());
+    }
+
+    /**
+     * Runs a document through the expansion and parses the result the way ConfigLib would.
+     *
+     * @param yaml the document
+     * @return the parsed document
+     */
+    @NotNull
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> expandAndParse(@NotNull String yaml) {
+        final String expanded = EnvironmentYaml.expand(yaml, ENV);
+        assertNotNull(expanded, "The document holds references, so it must have been rewritten");
+        return (Map<String, Object>) new Load(LoadSettings.builder().build()).loadFromString(expanded);
+    }
+
+}
+// XMine end - подстановка переменных среды в конфиге


### PR DESCRIPTION
### Зачем

Игровые ноды в Docker получают доступы к MariaDB и Redis переменными среды
(`DATABASE_HOST`, `DATABASE_PORT`, `DATABASE_USER`, `DATABASE_PASSWORD`,
`REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`), а конфиги лежат в git и в слое
образа, общем для всех нод, — секретов в них быть не должно. Форк Paper умеет
раскрывать `${NAME}` внутри YAML, но вклинивается ровно в
`org.bukkit.configuration.file.YamlConfiguration`; HuskSync читает `config.yml`
через ConfigLib поверх SnakeYAML Engine, куда подстановка ядра не доходит.

Ветка заведена от `master`, только что подтянутого по апстриму (fast-forward до
`c8ab839` = тег `4.0.0`) — это ровно то состояние, из которого собран jar в
проде: артефакт `ru.xmine.thirdparty:husksync:4.0.0-26.1.2` — зеркало релиза
апстрима, не сборка форка (XMineNode, коммит `1eecf29`).

**Этот PR заменяет закрытый #1.** Ветка называлась `xmine-env-config` (не
`xmine/env-config`, как у LibertyBans и SkinsRestorer), потому что в форке уже
была ветка `xmine`, и git не давал завести `xmine/*` рядом с ней. Легаси-ветка
`xmine` (там только патч `PlayerLoginEvent`, в прод не попадал) переименована в
`xmine/legacy-login-block`, пространство `xmine/*` освобождено, а эта ветка
следом переименована в `xmine/env-config` — для единообразия с соседями.
Переименование через API GitHub (`POST .../branches/{b}/rename`) не переносит
открытый PR на новое имя ветки, а молча закрывает его — это и произошло с #1.
Работа (два коммита) не потеряна, только PR пришлось переоткрыть.

### Что сделано

Семантика — ровно как в ядре (`EnvironmentSubstitutor` из `xmine/ver/26.1.2`
форка Paper): `${NAME}`, `${NAME:-запасное}`, экранирование `$${NAME}`, имена
`[A-Z_][A-Z0-9_]*`, незаданная переменная остаётся в тексте как есть,
подставленное значение не пересканируется. Ни значение переменной, ни
содержимое файла не логируются и не попадают в текст исключений.

Штатный механизм SnakeYAML не подошёл — **но не из-за тега**. В SnakeYAML
Engine (это она под ConfigLib, а не `org.yaml.snakeyaml`) `${...}` распознаётся
неявным резолвером `JsonScalarResolver` → `Tag.ENV_TAG`, писать `!ENV` не надо;
опасение из задачи относится к старой библиотеке, здесь его нет. Не подошёл он
по двум другим причинам:

* **ConfigLib не даёт точки подключения.** `YamlConfigurationStore` собирает
  загрузчик один раз, в `private static final` поле, из
  `LoadSettings.builder().build()` без `EnvConfig`, а его конструктор ещё и
  очищает `tagConstructors`. `YamlConfigurationProperties` на это никаких
  ручек не даёт.
* **Семантика `ENV_FORMAT` — не наша.** Шаблоном должен быть весь скаляр
  целиком; имя ловится как `\w+` (то есть `${player}` тоже переменная);
  значение по умолчанию тоже `\w+`, из-за чего `${HOST:-db.internal}` вообще не
  считается шаблоном; незаданная переменная превращается в пустую строку; `$$`
  не экранирует. `EnvConfig` ничего из этого не чинит — его зовут уже после
  того, как резолвер решил, что шаблон, а что нет.

Поэтому от SnakeYAML Engine взята его же модель документа — `Compose`
разбирает, `Serialize` и `Present` пишут обратно, — а подстановка идёт по
дереву узлов, как в ядре: раскрытое значение тогда не может ни изменить
структуру документа, ни попасть в текст ошибки разбора. Пароль со скобками,
двоеточиями и решётками переезжает целым, потому что квотит его сам эмиттер.

Попутно чинится то, что **HuskSync и без подстановки не читал наш конфиг**:
`port: ${DATABASE_PORT}` без кавычек получает `Tag.ENV_TAG`, и ConfigLib падает
с `could not determine a constructor for the tag !ENV_VARIABLE`. Проверено на
`XMineNode/config/plugins/common/HuskSync/config.yml`.

Конфиг с шаблонами больше **не перезаписывается** после чтения:
`YamlConfigurations.update()` сохраняет файл обратно, а к этому моменту в
объекте лежит пароль, а не шаблон. Конфиг без шаблонов идёт прежним апстримным
путём целиком, вместе с мержем новых ключей.

### Публикация в Reposilite (`xmine-publish.yml`)

Добавлен workflow публикации по образцу LibertyBans/SkinsRestorer/CoreProtect:
паблик-репозиторий → только `ubuntu-latest`, без `pull_request`, `if:
github.repository == 'XMineServer/HuskSync'`. Секреты — `MAVEN_USERNAME` /
`MAVEN_PASSWORD` (так они уже заведены в этом репозитории; у LibertyBans и
SkinsRestorer то же самое называется `XMINE_MAVEN_USERNAME`/`_PASSWORD` —
расхождение не унифицировано умышленно).

Публикуется только сборка Paper/Bukkit под **26.1.2** — версию, которую сейчас
фактически потребляет `XMineNode` (`plugins/common.yml`). Версия —
**`4.0.0-xmine.1-SNAPSHOT`**, настоящий Maven SNAPSHOT, а не неизменяемая
координата `<апстрим>-xmine.N`, как у LibertyBans/CoreProtect: первый прогон
стенда идёт сразу на форке, правки почти наверняка понадобятся не раз, а
SNAPSHOT можно перезаливать по тому же адресу. Ради этого в
`bukkit/build.gradle` добавлена настоящая `maven-publish`-публикация под нашей
координатой (только для модуля `26.1.2`, остальные bukkit-версии не
затронуты) — просто закинуть jar через `curl`, как у LibertyBans/CoreProtect,
здесь нельзя: для `-SNAPSHOT`-версии сам Reposilite обязан вести
`maven-metadata.xml` (`versioning/snapshot/timestamp` и `.../buildNumber`),
иначе `XMineNode/build/fetch.py::resolve_maven` не соберёт настоящее имя файла
и упадёт с `maven-metadata.xml has no complete versioning/snapshot`. Проверено
локально сквозным прогоном test → build → publish → verify против тестового
HTTP-сервера — `maven-metadata.xml` формируется корректно, оба поля на месте.

**Push-триггер `push: branches: ['xmine/**']` (как у LibertyBans/SkinsRestorer)
здесь пока сознательно не добавлен** — только `workflow_dispatch`. Секреты
`MAVEN_USERNAME`/`MAVEN_PASSWORD` в репозитории уже заведены, и добавь я
push-триггер сразу, этот же коммит с новым файлом сам вызвал бы первую
публикацию (GitHub матчит `on.push.branches` по дереву запушенного коммита).
Проверено эмпирически прямо на этом репозитории пробным workflow: событие
`push` порождает не только `git push`, но и переименование ветки через API на
совпадающее имя — обходного порядка действий, не считая ручной публикации, нет.
Включение push-триггера — однострочная правка, которую делает владелец, когда
решит, что пора (тем же движением это станет первым реальным запуском).

### Проверено

`./gradlew :common:test` — 58 тестов, 0 падений; `./gradlew
:bukkit:26.1.2:shadowJar` — успешно, версия и координата в `plugin.yml`
подтверждены прямым разбором собранного jar-а. `actionlint` — 0 замечаний по
новому файлу. Плюс прогон собранного `common` на настоящем
`XMineNode/config/plugins/common/HuskSync/config.yml`:
`host=mariadb port=3306 (int) user=plugins pass=[p@ss:w0rd #x]`.

### Нужно до слияния / до первой публикации

- [ ] Решение владельца по ветке `xmine/legacy-login-block` (бывшая `xmine`):
      патч `PlayerLoginEvent` (блокировка игрока до `PlayerJoinEvent`, форк
      3.2.2). В прод не попадал — переносить его или похоронить, решает
      владелец. Отдельный PR.
- [ ] Решение владельца по версии и тегу форка — в этом PR не проставлены
      (используется временная `4.0.0-xmine.1-SNAPSHOT`).
- [ ] Владелец включает push-триггер в `xmine-publish.yml`, когда решит, что
      пора публиковать (или запускает `workflow_dispatch` вручную) — сейчас
      публикация не настроена срабатывать сама.
- [ ] `XMineNode/plugins/common.yml` перевести с зеркала апстрима
      `ru.xmine.thirdparty:husksync:4.0.0-26.1.2` на координату
      `ru.xmine.thirdparty:husksync:4.0.0-xmine.1-SNAPSHOT` (`sha256` для
      SNAPSHOT не нужен — имя файла меняется при каждой публикации) — иначе
      правка до прода не доедет. Отдельный PR в `XMineNode`, после первой
      успешной публикации.
- [ ] Уточнить конвенцию комментариев в форках: здесь, как в LibertyBans,
      SkinsRestorer и форке Paper, javadoc на английском, а пометки
      `// XMine start — …` на русском.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N72TxirutocVwqk9dGMdw3
